### PR TITLE
Refactor state logic in player (server)

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -49,8 +49,13 @@ module.exports = class Player {
   }
 
   _start_prev() {
-    if (!this.playlist_loop || this.one_loop) return; // disabled
-    this._dec_playing_idx();
+    if (this.one_loop) {
+      // pass
+    } else if (this.playlist_loop) {
+      this._dec_playing_idx();
+    } else {
+      return; // disabled
+    }
     this._start();
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -38,16 +38,18 @@ module.exports = class Player {
   }
 
   _start_next() {
-    if (!this.playlist_loop) {
-      this.playlist.dequeue();
-    } else {
+    if (this.one_loop) {
+      // pass
+    } else if (this.playlist_loop) {
       this._inc_playing_idx();
+    } else {
+      this.playlist.dequeue();
     }
     this._start();
   }
 
   _start_prev() {
-    if (!this.playlist_loop) return;
+    if (!this.playlist_loop || this.one_loop) return; // disabled
     this._dec_playing_idx();
     this._start();
   }
@@ -85,12 +87,7 @@ module.exports = class Player {
       .on("close", () => {
         this.now_playing = false;
         this.ev.emit("update-status");
-
-        if (this.one_loop) {
-          this._start();
-        } else {
-          this._start_next();
-        }
+        this._start_next();
       });
   }
 


### PR DESCRIPTION
I refactored state logic in `src/player.js`.
- Removed `next_play_prev` (!!!).
- Extracted `_play_music()` from `_start()`.
- Created `_update_playing_contents()` used in `_start()`, `_start_next()` and `_start_prev()`.
- Created `_destroy()` used in `next()`, `prev()` and `stop()` that are controllers.
- Removed calling `_start_prev()` in `_start()`. 
    - `_start_prev()` is only called in `prev()` controller.
    -  `_start_next()` is called in `next()` controller and "close" event of audio_stream.
- Made controllers simple.
- Shortened logic of inc/dec playing index.