### PR TITLE
Impl throttle on update-status event (to websocket)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "koa-static": "^4.0.1",
     "koa-websocket": "^4.0.0",
     "lame": "^1.2.4",
+    "lodash.throttle": "^4.1.1",
     "speaker": "^0.3.0",
     "ytdl-core": "^0.15.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ const socket_route = require("koa-route");
 const mount = require("koa-mount");
 const bodyParser = require("koa-bodyparser");
 const path = require("path");
+const throttle = require("lodash.throttle");
 
 const websockify = require("koa-websocket");
 const app = websockify(new Koa());
@@ -39,9 +40,12 @@ app.ws.broadcast = data => {
   }
 };
 
-ev.on("update-status", () => {
-  app.ws.broadcast(JSON.stringify(player.fetch_status()));
-});
+ev.on(
+  "update-status",
+  throttle(() => {
+    app.ws.broadcast(JSON.stringify(player.fetch_status()));
+  }, 200)
+);
 
 // websocket connection
 app.ws.use(socket_route.get("/socket", ctx => {}));


### PR DESCRIPTION
"update-status" event on websocket is raised continuously.
I think it is necessary to use throttle on raising the event.