### PR TITLE
Add status store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
-/store/*.json
+/store/*
+!/store/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
-/store/status.json
+/store/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ typings/
 
 # dotenv environment variables file
 .env
+
+/store/status.json

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,13 @@ const playlist = new Playlist(ev);
 const Player = require("./player.js");
 const player = new Player(playlist, ev);
 
+// load status
+const PlayerStatusStore = require("./player_status_store.js");
+const player_status_store = new PlayerStatusStore();
+if (player_status_store.exists_sync()) {
+  player.set_status(player_status_store.read_sync());
+}
+
 const Router = require("./router");
 const router = new Router();
 router.all_bind(player, playlist);
@@ -43,7 +50,13 @@ app.ws.broadcast = data => {
 ev.on(
   "update-status",
   throttle(() => {
-    app.ws.broadcast(JSON.stringify(player.fetch_status()));
+    const status = player.fetch_status();
+    app.ws.broadcast(JSON.stringify(status));
+
+    // save status
+    player_status_store.write_sync(status, {
+      pretty: process.env.NODE_ENV !== "production"
+    });
   }, 200)
 );
 

--- a/src/player.js
+++ b/src/player.js
@@ -134,6 +134,22 @@ module.exports = class Player {
     };
   }
 
+  set_status(status) {
+    this.set_one_loop(status.one_loop);
+    this.set_playlist_loop(status.playlist_loop);
+    this.set_shuffle_mode(status.shuffle_mode);
+    this.playlist.replace(status.playlist);
+
+    // set update now_playing, now_playing_idx and now_playing_content
+    if (status.now_playing_idx) {
+      this.now_playing_idx = status.now_playing_idx;
+      this.now_playing_content = status.now_playing_content;
+      if (status.now_playing) {
+        this.start_specific(this.now_playing_idx);
+      }
+    }
+  }
+
   _inc_playing_idx() {
     if (this.one_loop) return;
     this.now_playing_idx = (this.now_playing_idx + 1) % this.playlist.length();

--- a/src/player_status_store.js
+++ b/src/player_status_store.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const path = require("path");
+const ENCODE_TYPE = "utf8";
+
+module.exports = class PlayerStatusStore {
+  read_sync() {
+    return JSON.parse(fs.readFileSync(this.store_path, ENCODE_TYPE));
+  }
+
+  write_sync(content, { pretty = false } = {}) {
+    const data = JSON.stringify(content, null, pretty ? "  " : null);
+    fs.writeFileSync(this.store_path, data, ENCODE_TYPE);
+  }
+
+  exists_sync() {
+    return fs.existsSync(this.store_path);
+  }
+
+  get store_path() {
+    return path.join(__dirname, "..", "store", "player_status.json");
+  }
+};


### PR DESCRIPTION
I implemented player status store.
**The destination of store is `store/player_status.json`.** This implementation is very very simple.
Why?
I think that the better implementation is using DBMS, but it complicates this program by DB config, migration, scheme and so on.
Jukebox should keep simple.