### PR TITLE
Add ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "airbnb-base"
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "comma-dangle": ["error", "never"],
     "arrow-parens": ["error", "as-needed"],
     "no-underscore-dangle": "off",
-    "no-plusplus": "off"
+    "no-plusplus": "off",
+    "no-console": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,20 @@
 {
-    "extends": "airbnb-base"
+  "extends": "airbnb-base",
+  "env": {
+    "browser": true,
+    "node": true,
+    "amd": true
+  },
+  "globals": {
+    "Vue": true,
+    "Clipboard": true
+  },
+  "rules": {
+    "no-new": "off",
+    "camelcase": "warn",
+    "comma-dangle": ["error", "never"],
+    "arrow-parens": ["error", "as-needed"],
+    "no-underscore-dangle": "off",
+    "no-plusplus": "off"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,6 @@
   },
   "rules": {
     "no-new": "off",
-    "camelcase": "warn",
     "comma-dangle": ["error", "never"],
     "arrow-parens": ["error", "as-needed"],
     "no-underscore-dangle": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "plugins": [
+    "prettier"
+  ],
   "extends": "airbnb-base",
   "env": {
     "browser": true,

--- a/assets/index.html
+++ b/assets/index.html
@@ -29,10 +29,10 @@
         </div>
         <div class="columns player-wrapper" id="app" v-cloak>
           <div class="column is-6">
-            <player :player="bind_player"></player>
+            <player :player="bindPlayer"></player>
           </div>
           <div class="column is-6">
-            <playlist :playlist="bind_playlist"></playlist>
+            <playlist :playlist="bindPlaylist"></playlist>
           </div>
         </div>
       </div>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,19 +3,21 @@ new Vue({
   data: {
     player_status: {},
     bind_player: {},
-    bind_playlist: {},
+    bind_playlist: {}
   },
   async created() {
     await this.init();
     this.setup_socket();
   },
   watch: {
-    'player_status.now_playing': function (now_playing) {
-      const app_name = 'jukebox';
-      document.title = now_playing
-        ? `${this.player_status.now_playing_content.title} - ${app_name}`
-        : app_name;
-    },
+    player_status: {
+      now_playing(now_playing) {
+        const app_name = 'jukebox';
+        document.title = now_playing
+          ? `${this.player_status.now_playing_content.title} - ${app_name}`
+          : app_name;
+      }
+    }
   },
   methods: {
     async init() {
@@ -31,12 +33,12 @@ new Vue({
         now_playing: this.player_status.now_playing,
         now_playing_idx: this.player_status.now_playing_idx,
         now_playing_content: this.player_status.now_playing_content,
-        playlist: this.player_status.playlist,
+        playlist: this.player_status.playlist
       };
       this.bind_playlist = {
         contents: this.player_status.playlist,
         now_playing_content: this.player_status.now_playing_content,
-        now_playing_idx: this.player_status.now_playing_idx,
+        now_playing_idx: this.player_status.now_playing_idx
       };
     },
     teardown() {
@@ -47,7 +49,7 @@ new Vue({
     setup_socket() {
       const socket = new WebSocket(`ws://${location.host}/socket`);
 
-      socket.addEventListener('message', (event) => {
+      socket.addEventListener('message', event => {
         this.player_status = JSON.parse(event.data);
         this.bind_update();
       });
@@ -58,6 +60,6 @@ new Vue({
           this.setup_socket();
         }, 1000);
       });
-    },
-  },
+    }
+  }
 });

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -10,19 +10,20 @@ new Vue({
     this.setupSocket();
   },
   watch: {
-    playerStatus: {
-      nowPlaying(nowPlaying) {
-        const appName = 'jukebox';
-        document.title = nowPlaying
-          ? `${this.playerStatus.nowPlayingContent.title} - ${appName}`
-          : appName;
-      }
+    /* eslint-disable no-useless-computed-key, object-shorthand */
+    ['player_status.nowPlaying'](nowPlaying) {
+      const appName = 'jukebox';
+      document.title = nowPlaying
+        ? `${this.playerStatus.nowPlayingContent.title} - ${appName}`
+        : appName;
     }
+    /* eslint-enable no-useless-computed-key, object-shorthand */
   },
   methods: {
     async init() {
       const res = await fetch('/player/status');
       this.playerStatus = await res.json();
+      console.log(this.playerStatus);
       this.bindUpdate();
     },
     bindUpdate() {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -11,7 +11,7 @@ new Vue({
   },
   watch: {
     /* eslint-disable no-useless-computed-key, object-shorthand */
-    ['player_status.nowPlaying'](nowPlaying) {
+    ['playerStatus.nowPlaying'](nowPlaying) {
       const appName = 'jukebox';
       document.title = nowPlaying
         ? `${this.playerStatus.nowPlayingContent.title} - ${appName}`
@@ -23,7 +23,6 @@ new Vue({
     async init() {
       const res = await fetch('/player/status');
       this.playerStatus = await res.json();
-      console.log(this.playerStatus);
       this.bindUpdate();
     },
     bindUpdate() {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,63 +1,63 @@
 new Vue({
   el: '#app',
   data: {
-    player_status: {},
-    bind_player: {},
-    bind_playlist: {}
+    playerStatus: {},
+    bindPlayer: {},
+    bindPlaylist: {}
   },
   async created() {
     await this.init();
-    this.setup_socket();
+    this.setupSocket();
   },
   watch: {
-    player_status: {
-      now_playing(now_playing) {
-        const app_name = 'jukebox';
-        document.title = now_playing
-          ? `${this.player_status.now_playing_content.title} - ${app_name}`
-          : app_name;
+    playerStatus: {
+      nowPlaying(nowPlaying) {
+        const appName = 'jukebox';
+        document.title = nowPlaying
+          ? `${this.playerStatus.nowPlayingContent.title} - ${appName}`
+          : appName;
       }
     }
   },
   methods: {
     async init() {
       const res = await fetch('/player/status');
-      this.player_status = await res.json();
-      this.bind_update();
+      this.playerStatus = await res.json();
+      this.bindUpdate();
     },
-    bind_update() {
-      this.bind_player = {
-        one_loop: this.player_status.one_loop,
-        playlist_loop: this.player_status.playlist_loop,
-        shuffle_mode: this.player_status.shuffle_mode,
-        now_playing: this.player_status.now_playing,
-        now_playing_idx: this.player_status.now_playing_idx,
-        now_playing_content: this.player_status.now_playing_content,
-        playlist: this.player_status.playlist
+    bindUpdate() {
+      this.bindPlayer = {
+        oneLoop: this.playerStatus.oneLoop,
+        playlistLoop: this.playerStatus.playlistLoop,
+        shuffleMode: this.playerStatus.shuffleMode,
+        nowPlaying: this.playerStatus.nowPlaying,
+        nowPlayingIdx: this.playerStatus.nowPlayingIdx,
+        nowPlayingContent: this.playerStatus.nowPlayingContent,
+        playlist: this.playerStatus.playlist
       };
-      this.bind_playlist = {
-        contents: this.player_status.playlist,
-        now_playing_content: this.player_status.now_playing_content,
-        now_playing_idx: this.player_status.now_playing_idx
+      this.bindPlaylist = {
+        contents: this.playerStatus.playlist,
+        nowPlayingContent: this.playerStatus.nowPlayingContent,
+        nowPlayingIdx: this.playerStatus.nowPlayingIdx
       };
     },
     teardown() {
-      this.player_status = {};
-      this.bind_player = {};
-      this.bind_playlist = {};
+      this.playerStatus = {};
+      this.bindPlayer = {};
+      this.bindPlaylist = {};
     },
-    setup_socket() {
+    setupSocket() {
       const socket = new WebSocket(`ws://${location.host}/socket`);
 
       socket.addEventListener('message', event => {
-        this.player_status = JSON.parse(event.data);
-        this.bind_update();
+        this.playerStatus = JSON.parse(event.data);
+        this.bindUpdate();
       });
       socket.addEventListener('close', () => {
         this.teardown();
         setTimeout(() => {
           this.init();
-          this.setup_socket();
+          this.setupSocket();
         }, 1000);
       });
     }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,25 +1,25 @@
 new Vue({
-  el: "#app",
+  el: '#app',
   data: {
     player_status: {},
     bind_player: {},
-    bind_playlist: {}
+    bind_playlist: {},
   },
   async created() {
     await this.init();
     this.setup_socket();
   },
   watch: {
-    ["player_status.now_playing"](now_playing) {
-      const app_name = "jukebox";
+    'player_status.now_playing': function (now_playing) {
+      const app_name = 'jukebox';
       document.title = now_playing
         ? `${this.player_status.now_playing_content.title} - ${app_name}`
         : app_name;
-    }
+    },
   },
   methods: {
     async init() {
-      const res = await fetch("/player/status");
+      const res = await fetch('/player/status');
       this.player_status = await res.json();
       this.bind_update();
     },
@@ -31,12 +31,12 @@ new Vue({
         now_playing: this.player_status.now_playing,
         now_playing_idx: this.player_status.now_playing_idx,
         now_playing_content: this.player_status.now_playing_content,
-        playlist: this.player_status.playlist
+        playlist: this.player_status.playlist,
       };
       this.bind_playlist = {
         contents: this.player_status.playlist,
         now_playing_content: this.player_status.now_playing_content,
-        now_playing_idx: this.player_status.now_playing_idx
+        now_playing_idx: this.player_status.now_playing_idx,
       };
     },
     teardown() {
@@ -47,17 +47,17 @@ new Vue({
     setup_socket() {
       const socket = new WebSocket(`ws://${location.host}/socket`);
 
-      socket.addEventListener("message", event => {
+      socket.addEventListener('message', (event) => {
         this.player_status = JSON.parse(event.data);
         this.bind_update();
       });
-      socket.addEventListener("close", () => {
+      socket.addEventListener('close', () => {
         this.teardown();
         setTimeout(() => {
           this.init();
           this.setup_socket();
         }, 1000);
       });
-    }
-  }
+    },
+  },
 });

--- a/assets/js/links-sender.js
+++ b/assets/js/links-sender.js
@@ -1,9 +1,9 @@
-Vue.component("links-sender", {
+Vue.component('links-sender', {
   data() {
     return {
       unavaliable_links: [],
-      input: "",
-      adding: false
+      input: '',
+      adding: false,
     };
   },
   methods: {
@@ -11,17 +11,17 @@ Vue.component("links-sender", {
       if (this.input.length === 0) return;
       try {
         this.adding = true;
-        const res = await fetch("/playlist", {
-          method: "POST",
+        const res = await fetch('/playlist', {
+          method: 'POST',
           headers: {
-            "Content-Type": "application/json"
+            'Content-Type': 'application/json',
           },
-          body: JSON.stringify(this.input.split(","))
+          body: JSON.stringify(this.input.split(',')),
         });
         this.adding = false;
         if (!res.ok) return;
         this.unavaliable_links = await res.json();
-        this.input = "";
+        this.input = '';
         setTimeout(() => {
           this.clear_unavaliable_links();
         }, 30000);
@@ -35,7 +35,7 @@ Vue.component("links-sender", {
     },
     is_unavaliable_links_empty() {
       return this.unavaliable_links.length === 0;
-    }
+    },
   },
   template: `
   <div class="links-sender">
@@ -70,5 +70,5 @@ Vue.component("links-sender", {
       </div>
     </form>
   </div>
-  `
+  `,
 });

--- a/assets/js/links-sender.js
+++ b/assets/js/links-sender.js
@@ -3,7 +3,7 @@ Vue.component('links-sender', {
     return {
       unavaliable_links: [],
       input: '',
-      adding: false,
+      adding: false
     };
   },
   methods: {
@@ -14,9 +14,9 @@ Vue.component('links-sender', {
         const res = await fetch('/playlist', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
+            'Content-Type': 'application/json'
           },
-          body: JSON.stringify(this.input.split(',')),
+          body: JSON.stringify(this.input.split(','))
         });
         this.adding = false;
         if (!res.ok) return;
@@ -35,7 +35,7 @@ Vue.component('links-sender', {
     },
     is_unavaliable_links_empty() {
       return this.unavaliable_links.length === 0;
-    },
+    }
   },
   template: `
   <div class="links-sender">
@@ -70,5 +70,5 @@ Vue.component('links-sender', {
       </div>
     </form>
   </div>
-  `,
+  `
 });

--- a/assets/js/links-sender.js
+++ b/assets/js/links-sender.js
@@ -1,13 +1,13 @@
 Vue.component('links-sender', {
   data() {
     return {
-      unavaliable_links: [],
+      unavaliableLinks: [],
       input: '',
       adding: false
     };
   },
   methods: {
-    async playlist_add() {
+    async playlistAdd() {
       if (this.input.length === 0) return;
       try {
         this.adding = true;
@@ -20,26 +20,26 @@ Vue.component('links-sender', {
         });
         this.adding = false;
         if (!res.ok) return;
-        this.unavaliable_links = await res.json();
+        this.unavaliableLinks = await res.json();
         this.input = '';
         setTimeout(() => {
-          this.clear_unavaliable_links();
+          this.clearUnavaliableLinks();
         }, 30000);
       } catch (e) {
         this.adding = false;
         console.error(e);
       }
     },
-    clear_unavaliable_links() {
-      this.unavaliable_links = [];
+    clearUnavaliableLinks() {
+      this.unavaliableLinks = [];
     },
-    is_unavaliable_links_empty() {
-      return this.unavaliable_links.length === 0;
+    isUnavaliableLinksEmpty() {
+      return this.unavaliableLinks.length === 0;
     }
   },
   template: `
   <div class="links-sender">
-    <form action="#" @submit.prevent="playlist_add">
+    <form action="#" @submit.prevent="playlistAdd">
       <div class="field has-addons">
         <div class="control is-expanded">
           <input
@@ -59,11 +59,11 @@ Vue.component('links-sender', {
           </button>
         </p>
       </div>
-      <div v-if="!is_unavaliable_links_empty()" class="field">
+      <div v-if="!isUnavaliableLinksEmpty()" class="field">
         <div class="message is-danger">
           <div class="message-body error-msg">
-            <div v-for="link in unavaliable_links">
-              '{{ link.link }}' => '{{ link.err_msg }}'
+            <div v-for="link in unavaliableLinks">
+              '{{ link.link }}' => '{{ link.errMsg }}'
             </div>
           </div>
         </div>

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -37,7 +37,7 @@ Vue.component('player', {
       } else {
         fetch('/player/loop/shuffle/on', { method: 'POST' });
       }
-    },
+    }
   },
   computed: {
     exist_thumbnail() {
@@ -45,7 +45,7 @@ Vue.component('player', {
         this.player.now_playing_content &&
         this.player.now_playing_content.thumbnail_link
       );
-    },
+    }
   },
 
   template: `
@@ -107,5 +107,5 @@ Vue.component('player', {
       </div>
     </div>
   </div>
-  `,
+  `
 });

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -2,37 +2,37 @@ Vue.component('player', {
   props: ['player'],
 
   methods: {
-    is_playlist_empty() {
+    isPlaylistEmpty() {
       return !this.player.playlist || this.player.playlist.length === 0;
     },
-    player_start() {
+    playerStart() {
       fetch('/player/start', { method: 'POST' });
     },
-    player_pause() {
+    playerPause() {
       fetch('/player/pause', { method: 'POST' });
     },
-    player_next() {
+    playerNext() {
       fetch('/player/next', { method: 'POST' });
     },
-    player_prev() {
+    playerPrev() {
       fetch('/player/prev', { method: 'POST' });
     },
-    player_loop_one_toggle() {
-      if (this.player.one_loop) {
+    playerLoopOneToggle() {
+      if (this.player.oneLoop) {
         fetch('/player/loop/one/off', { method: 'POST' });
       } else {
         fetch('/player/loop/one/on', { method: 'POST' });
       }
     },
-    player_loop_playlist_toggle() {
-      if (this.player.playlist_loop) {
+    playerLoopPlaylistToggle() {
+      if (this.player.playlistLoop) {
         fetch('/player/loop/playlist/off', { method: 'POST' });
       } else {
         fetch('/player/loop/playlist/on', { method: 'POST' });
       }
     },
-    player_shuffle_mode_toggle() {
-      if (this.player.shuffle_mode) {
+    playerShuffleModeToggle() {
+      if (this.player.shuffleMode) {
         fetch('/player/loop/shuffle/off', { method: 'POST' });
       } else {
         fetch('/player/loop/shuffle/on', { method: 'POST' });
@@ -40,47 +40,47 @@ Vue.component('player', {
     }
   },
   computed: {
-    exist_thumbnail() {
+    existThumbnail() {
       return (
-        this.player.now_playing_content &&
-        this.player.now_playing_content.thumbnail_link
+        this.player.nowPlayingContent &&
+        this.player.nowPlayingContent.thumbnailLink
       );
     }
   },
 
   template: `
   <div class="player is-flex black-background">
-    <img v-if="exist_thumbnail" :src="player.now_playing_content.thumbnail_link" alt="Image" class="player-thumbnail is-block">
+    <img v-if="existThumbnail" :src="player.nowPlayingContent.thumbnailLink" alt="Image" class="player-thumbnail is-block">
     <div class="player-overlay is-flex">
       <h1 class="title is-4 player-title is-marginless">
-        <a :href="player.now_playing_content.link" target="_blank"
-        v-if="player.now_playing_content"
-        class="has-text-white" :title="player.now_playing_content.title">
-          {{ player.now_playing_content.title }}
+        <a :href="player.nowPlayingContent.link" target="_blank"
+        v-if="player.nowPlayingContent"
+        class="has-text-white" :title="player.nowPlayingContent.title">
+          {{ player.nowPlayingContent.title }}
         </a>
         <span v-else>&nbsp;</span>
       </h1>
       <div class="player-main-controller has-text-centered">
         <div class="columns is-mobile">
           <div class="column">
-            <a title="Prev" :class="{ 'deactivate': !player.playlist_loop || is_playlist_empty() }" @click="player_prev()">
+            <a title="Prev" :class="{ 'deactivate': !player.playlistLoop || isPlaylistEmpty() }" @click="playerPrev()">
               <i class="material-icons is-large is-pushable">skip_previous</i>
             </a>
           </div>
           <div class="column">
-            <div v-if="player.now_playing">
-              <a title="Pause" @click="player_pause()" :class="{ 'deactivate': is_playlist_empty() && !player.now_playing_content }">
+            <div v-if="player.nowPlaying">
+              <a title="Pause" @click="playerPause()" :class="{ 'deactivate': isPlaylistEmpty() && !player.nowPlayingContent }">
                 <i class="material-icons is-large is-pushable">pause</i>
               </a>
             </div>
             <div v-else>
-              <a title="Play" @click="player_start()" :class="{ 'deactivate': is_playlist_empty() && !player.now_playing_content }">
+              <a title="Play" @click="playerStart()" :class="{ 'deactivate': isPlaylistEmpty() && !player.nowPlayingContent }">
                 <i class="material-icons is-large is-pushable">play_arrow</i>
               </a>
             </div>
           </div>
           <div class="column">
-            <a title="Next" @click="player_next()" :class="{ 'deactivate': is_playlist_empty() }">
+            <a title="Next" @click="playerNext()" :class="{ 'deactivate': isPlaylistEmpty() }">
               <i class="material-icons is-large is-pushable">skip_next</i>
             </a>
           </div>
@@ -89,17 +89,17 @@ Vue.component('player', {
       <div class="player-other-controller">
         <div class="columns has-text-centered is-mobile">
           <div class="column">
-            <a title="One Loop" :class="[{ 'is-loop-active': player.one_loop }, { 'deactivate': is_playlist_empty() && !player.now_playing_content }]" @click="player_loop_one_toggle()">
+            <a title="One Loop" :class="[{ 'is-loop-active': player.oneLoop }, { 'deactivate': isPlaylistEmpty() && !player.nowPlayingContent }]" @click="playerLoopOneToggle()">
               <i class="material-icons is-medium">repeat_one</i>
             </a>
           </div>
           <div class="column">
-            <a title="Playlist Loop" :class="[{ 'is-loop-active': player.playlist_loop }, { 'deactivate': is_playlist_empty() }]" @click="player_loop_playlist_toggle()">
+            <a title="Playlist Loop" :class="[{ 'is-loop-active': player.playlistLoop }, { 'deactivate': isPlaylistEmpty() }]" @click="playerLoopPlaylistToggle()">
               <i class="material-icons is-medium">repeat</i>
             </a>
           </div>
           <div class="column">
-            <a title="Shuffle" :class="[{ 'is-loop-active': player.shuffle_mode }, { 'deactivate': is_playlist_empty() }]" @click="player_shuffle_mode_toggle()">
+            <a title="Shuffle" :class="[{ 'is-loop-active': player.shuffleMode }, { 'deactivate': isPlaylistEmpty() }]" @click="playerShuffleModeToggle()">
               <i class="material-icons is-medium">shuffle</i>
             </a>
           </div>

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -1,43 +1,43 @@
-Vue.component("player", {
-  props: ["player"],
+Vue.component('player', {
+  props: ['player'],
 
   methods: {
     is_playlist_empty() {
       return !this.player.playlist || this.player.playlist.length === 0;
     },
     player_start() {
-      fetch("/player/start", { method: "POST" });
+      fetch('/player/start', { method: 'POST' });
     },
     player_pause() {
-      fetch("/player/pause", { method: "POST" });
+      fetch('/player/pause', { method: 'POST' });
     },
     player_next() {
-      fetch("/player/next", { method: "POST" });
+      fetch('/player/next', { method: 'POST' });
     },
     player_prev() {
-      fetch("/player/prev", { method: "POST" });
+      fetch('/player/prev', { method: 'POST' });
     },
     player_loop_one_toggle() {
       if (this.player.one_loop) {
-        fetch("/player/loop/one/off", { method: "POST" });
+        fetch('/player/loop/one/off', { method: 'POST' });
       } else {
-        fetch("/player/loop/one/on", { method: "POST" });
+        fetch('/player/loop/one/on', { method: 'POST' });
       }
     },
     player_loop_playlist_toggle() {
       if (this.player.playlist_loop) {
-        fetch("/player/loop/playlist/off", { method: "POST" });
+        fetch('/player/loop/playlist/off', { method: 'POST' });
       } else {
-        fetch("/player/loop/playlist/on", { method: "POST" });
+        fetch('/player/loop/playlist/on', { method: 'POST' });
       }
     },
     player_shuffle_mode_toggle() {
       if (this.player.shuffle_mode) {
-        fetch("/player/loop/shuffle/off", { method: "POST" });
+        fetch('/player/loop/shuffle/off', { method: 'POST' });
       } else {
-        fetch("/player/loop/shuffle/on", { method: "POST" });
+        fetch('/player/loop/shuffle/on', { method: 'POST' });
       }
-    }
+    },
   },
   computed: {
     exist_thumbnail() {
@@ -45,7 +45,7 @@ Vue.component("player", {
         this.player.now_playing_content &&
         this.player.now_playing_content.thumbnail_link
       );
-    }
+    },
   },
 
   template: `
@@ -107,5 +107,5 @@ Vue.component("player", {
       </div>
     </div>
   </div>
-  `
+  `,
 });

--- a/assets/js/playlist.js
+++ b/assets/js/playlist.js
@@ -1,12 +1,12 @@
-Vue.component("playlist", {
-  props: ["playlist"],
+Vue.component('playlist', {
+  props: ['playlist'],
   data() {
     return {
-      clipboard: null
+      clipboard: null,
     };
   },
   created() {
-    this.clipboard = new Clipboard(".copy-link-button");
+    this.clipboard = new Clipboard('.copy-link-button');
   },
 
   methods: {
@@ -17,7 +17,7 @@ Vue.component("playlist", {
       const s = seconds % 60;
       const m = Math.floor(seconds % 3600 / 60);
       const h = Math.floor(seconds / 3600);
-      const padding = num => ("00" + num).slice(-2);
+      const padding = num => (`00${num}`).slice(-2);
       return `${padding(h)}:${padding(m)}:${padding(s)}`;
     },
     is_now_playing_content(idx) {
@@ -27,19 +27,19 @@ Vue.component("playlist", {
       );
     },
     playlist_clear() {
-      fetch("/playlist", { method: "DELETE" });
+      fetch('/playlist', { method: 'DELETE' });
     },
     delete_content(index) {
-      fetch(`/playlist/${index}`, { method: "DELETE" });
+      fetch(`/playlist/${index}`, { method: 'DELETE' });
     },
     play_music(index) {
-      fetch(`/player/seek/${index}`, { method: "POST" });
-    }
+      fetch(`/player/seek/${index}`, { method: 'POST' });
+    },
   },
   computed: {
     is_playlist_empty() {
       return !this.playlist.contents || this.playlist.contents.length === 0;
-    }
+    },
   },
 
   template: `
@@ -96,5 +96,5 @@ Vue.component("playlist", {
       </div>
     </div>
   </div>
-  `
+  `,
 });

--- a/assets/js/playlist.js
+++ b/assets/js/playlist.js
@@ -13,31 +13,31 @@ Vue.component('playlist', {
     copyUrl(e) {
       this.clipboard.onClick(e);
     },
-    humanize_time(seconds) {
+    humanizeTime(seconds) {
       const s = seconds % 60;
       const m = Math.floor((seconds % 3600) / 60);
       const h = Math.floor(seconds / 3600);
       const padding = num => (`00${num}`).slice(-2);
       return `${padding(h)}:${padding(m)}:${padding(s)}`;
     },
-    is_now_playing_content(idx) {
+    isNowPlayingContent(idx) {
       return (
-        this.playlist.now_playing_content &&
-        this.playlist.now_playing_idx === idx
+        this.playlist.nowPlayingContent &&
+        this.playlist.nowPlayingIdx === idx
       );
     },
-    playlist_clear() {
+    playlistClear() {
       fetch('/playlist', { method: 'DELETE' });
     },
-    delete_content(index) {
+    deleteContent(index) {
       fetch(`/playlist/${index}`, { method: 'DELETE' });
     },
-    play_music(index) {
+    playMusic(index) {
       fetch(`/player/seek/${index}`, { method: 'POST' });
     }
   },
   computed: {
-    is_playlist_empty() {
+    isPlaylistEmpty() {
       return !this.playlist.contents || this.playlist.contents.length === 0;
     }
   },
@@ -49,22 +49,22 @@ Vue.component('playlist', {
     }">
     <div class="panel scroll-view" v-show="playlist && playlist.contents && playlist.contents.length">
       <a v-for="(content,idx) in playlist.contents" class="panel-block playlist-content is-paddingless"
-          :class="{'now-playing-content is-active':is_now_playing_content(idx)}"
+          :class="{'now-playing-content is-active':isNowPlayingContent(idx)}"
           :title="content.title"
-          @click="play_music(idx)"
+          @click="playMusic(idx)"
           >
           <div class="control columns is-marginless is-mobile">
             <div class="column is-1 align-self-center has-text-centered is-paddingless-vertical thumbnail-wrapper">
-              <span class="panel-icon" v-if="is_now_playing_content(idx)">
+              <span class="panel-icon" v-if="isNowPlayingContent(idx)">
                 <i class="material-icons icon">equalizer</i>
               </span>
-              <img :src="content.thumbnail_link" v-else class="is-block">
+              <img :src="content.thumbnailLink" v-else class="is-block">
             </div>
             <div class="column is-7 playlist-content-title-wrapper">
               {{ content.title }}
             </div>
             <div class="column has-text-centered is-2">
-              {{ humanize_time(content.length_seconds) }}
+              {{ humanizeTime(content.lengthSeconds) }}
             </div>
             <div class="column is-1 has-text-centered align-self-center is-paddingless-vertical">
               <a class="is-flex in-content-button copy-link-button" @click.prevent.stop="copyUrl" :data-clipboard-text="content.link">
@@ -72,7 +72,7 @@ Vue.component('playlist', {
               </a>
             </div>
             <div class="column is-1 has-text-centered align-self-center is-paddingless-vertical">
-              <a class="is-flex in-content-button" @click.prevent.stop="delete_content(idx)">
+              <a class="is-flex in-content-button" @click.prevent.stop="deleteContent(idx)">
                 <i class="material-icons icon" title="Delete">&#xE872;</i>
               </a>
             </div>
@@ -84,8 +84,8 @@ Vue.component('playlist', {
         <button
           title="Clear Playlist"
           class="button playlist-clear-button is-outlined is-fullwidth is-paddingless"
-          :disabled="is_playlist_empty"
-          @click="playlist_clear">
+          :disabled="isPlaylistEmpty"
+          @click="playlistClear">
           <i class="material-icons icon">delete_sweep</i>
         </button>
       </div>

--- a/assets/js/playlist.js
+++ b/assets/js/playlist.js
@@ -2,7 +2,7 @@ Vue.component('playlist', {
   props: ['playlist'],
   data() {
     return {
-      clipboard: null,
+      clipboard: null
     };
   },
   created() {
@@ -15,7 +15,7 @@ Vue.component('playlist', {
     },
     humanize_time(seconds) {
       const s = seconds % 60;
-      const m = Math.floor(seconds % 3600 / 60);
+      const m = Math.floor((seconds % 3600) / 60);
       const h = Math.floor(seconds / 3600);
       const padding = num => (`00${num}`).slice(-2);
       return `${padding(h)}:${padding(m)}:${padding(s)}`;
@@ -34,12 +34,12 @@ Vue.component('playlist', {
     },
     play_music(index) {
       fetch(`/player/seek/${index}`, { method: 'POST' });
-    },
+    }
   },
   computed: {
     is_playlist_empty() {
       return !this.playlist.contents || this.playlist.contents.length === 0;
-    },
+    }
   },
 
   template: `
@@ -96,5 +96,5 @@ Vue.component('playlist', {
       </div>
     </div>
   </div>
-  `,
+  `
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,29 @@
         "negotiator": "0.6.1"
       }
     },
+    "acorn": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -27,6 +50,12 @@
         "co": "4.6.0",
         "json-stable-stringify": "1.0.1"
       }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -102,10 +131,31 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
@@ -146,6 +196,17 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -207,10 +268,31 @@
         "repeat-element": "1.1.2"
       }
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "bytes": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -252,6 +334,12 @@
       "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
       "dev": true
     },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -277,6 +365,12 @@
         "string-width": "1.0.2"
       }
     },
+    "cli-width": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -299,6 +393,21 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -318,6 +427,55 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "configstore": {
       "version": "1.4.0",
@@ -342,6 +500,12 @@
           "dev": true
         }
       }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -447,6 +611,27 @@
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -466,6 +651,24 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "doctrine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -583,10 +786,190 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.3.0.tgz",
+      "integrity": "sha1-/NfJY3a780yF7mftABKimWQrEI8=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.2.2",
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.2.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.9.1",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "4.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.4.1",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.1",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz",
+      "integrity": "sha512-BXVH7PV5yiLjnkv49iOLJ8dWp+ljZf310ytQpqwrunFADiEbWRyN0tPGDU36FgEbdLvhJDWcJOngYDzPF4shDw==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "0.1.1"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "resolve": "1.4.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.1",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "espree": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-jsx": "3.0.1"
+      }
+    },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-stream": {
@@ -648,6 +1031,25 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
+    "external-editor": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.18",
+        "jschardet": "1.5.0",
+        "tmp": "0.0.31"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+          "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+          "dev": true
+        }
+      }
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -662,6 +1064,18 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -669,6 +1083,16 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
         "object-assign": "4.1.1"
       }
     },
@@ -689,6 +1113,28 @@
         "randomatic": "1.1.7",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "fluent-ffmpeg": {
@@ -741,6 +1187,24 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -762,6 +1226,20 @@
         }
       }
     },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
@@ -779,6 +1257,26 @@
       "dev": true,
       "requires": {
         "is-glob": "2.0.1"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "got": {
@@ -827,6 +1325,15 @@
         "har-schema": "1.0.5"
       }
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -835,6 +1342,12 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "hawk": {
       "version": "3.1.3",
@@ -851,6 +1364,12 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
     },
     "html-entities": {
       "version": "1.2.1",
@@ -910,6 +1429,12 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
       "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
     },
+    "ignore": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "dev": true
+    },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -942,6 +1467,16 @@
       "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
       "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -952,6 +1487,133 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
+    },
+    "inquirer": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.0.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.1.0",
+        "external-editor": "2.0.4",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -973,6 +1635,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-ci": {
       "version": "1.0.10",
@@ -1057,6 +1728,30 @@
         "kind-of": "3.2.2"
       }
     },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -1080,6 +1775,15 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1124,6 +1828,12 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
@@ -1140,10 +1850,22 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "jschardet": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.0.tgz",
+      "integrity": "sha512-+Q8JsoEQbrdE+a/gg1F9XO92gcKXgpE5UACqr0sIubjDmBEkd+OOWPGzQeMrWSLxd73r4dHxBeRW7edHu5LmJQ==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1366,6 +2088,16 @@
         "package-json": "1.2.0"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
     "lint-staged": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.0.2.tgz",
@@ -1449,6 +2181,36 @@
         "figures": "1.7.0"
       }
     },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -1514,6 +2276,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
       "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
+      "dev": true
+    },
+    "lodash.cond": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
     "lodash.defaults": {
@@ -1674,6 +2442,12 @@
         "mime-db": "1.29.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
     "miniget": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/miniget/-/miniget-1.0.0.tgz",
@@ -1716,6 +2490,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "mz": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
@@ -1730,6 +2510,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -1770,6 +2556,18 @@
       "dev": true,
       "requires": {
         "abbrev": "1.1.0"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -1861,6 +2659,20 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
     "ora": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
@@ -1900,6 +2712,21 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
     },
     "p-map": {
       "version": "1.1.1",
@@ -1943,15 +2770,36 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
     },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
@@ -1960,6 +2808,15 @@
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "requires": {
         "isarray": "0.0.1"
+      }
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
       }
     },
     "pause-stream": {
@@ -1976,6 +2833,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -1990,6 +2853,27 @@
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluralize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -2013,6 +2897,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
     },
     "promise-memorize": {
       "version": "1.1.0",
@@ -2151,6 +3041,38 @@
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -2323,6 +3245,31 @@
       "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
       "dev": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
     "resolve-path": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.3.3.tgz",
@@ -2357,6 +3304,39 @@
       "requires": {
         "exit-hook": "1.1.1",
         "onetime": "1.1.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
       }
     },
     "rxjs": {
@@ -2444,6 +3424,27 @@
       "requires": {
         "hoek": "2.16.3"
       }
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
     },
     "speaker": {
       "version": "0.3.0",
@@ -2603,6 +3604,12 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -2633,6 +3640,59 @@
       "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
       "dev": true
     },
+    "table": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
+      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "thenify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
@@ -2661,6 +3721,15 @@
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
       "dev": true
     },
+    "tmp": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "touch": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
@@ -2678,6 +3747,12 @@
         "punycode": "1.4.1"
       }
     },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2692,6 +3767,15 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -2700,6 +3784,12 @@
         "media-typer": "0.3.0",
         "mime-types": "2.1.16"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "ultron": {
       "version": "1.1.0",
@@ -2753,6 +3843,16 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
@@ -2783,11 +3883,26 @@
         "isexe": "2.0.0"
       }
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,16 @@
         "js-tokens": "3.0.2"
       }
     },
+    "babel-runtime": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -238,6 +248,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
+    "boolify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
+      "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
+      "dev": true
     },
     "boom": {
       "version": "2.10.1",
@@ -293,6 +309,23 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.1.0.tgz",
+      "integrity": "sha1-IU00jMVFfzkxaiwxzD43JGMl5z8=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0",
+        "map-obj": "2.0.0",
+        "quick-lru": "1.1.0"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -371,6 +404,17 @@
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
     },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -421,6 +465,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
+    },
+    "common-tags": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
+      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.25.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -531,6 +584,12 @@
       "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
       "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
     },
+    "core-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -571,6 +630,15 @@
         "boom": "2.10.1"
       }
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.26"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -599,6 +667,12 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -651,6 +725,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dlv": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.0.tgz",
+      "integrity": "sha1-/uGnxD9jvnXz9nnoUmLaXxAnZKc=",
+      "dev": true
     },
     "doctrine": {
       "version": "2.0.0",
@@ -769,11 +849,81 @@
       "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
       "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
     },
+    "es5-ext": {
+      "version": "0.10.26",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
+      "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.26",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.26",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.26",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.26"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.26",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -785,6 +935,18 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "4.3.0",
@@ -909,6 +1071,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.2.tgz",
+      "integrity": "sha1-S5D07n+Sv74ukmAX4cpA62KJZeo=",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.1",
+        "jest-docblock": "20.0.3"
+      }
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
@@ -971,6 +1143,16 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.26"
+      }
     },
     "event-stream": {
       "version": "3.3.4",
@@ -1068,6 +1250,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.1.tgz",
+      "integrity": "sha1-CuoOTmBbaiGJ8Ok21Lf7rxt8/Zs=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -1203,6 +1391,33 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "get-stream": {
@@ -1615,6 +1830,18 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1713,6 +1940,18 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -1770,6 +2009,12 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -1795,6 +2040,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -1827,6 +2078,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jest-docblock": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+      "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -1884,6 +2141,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2086,6 +2349,15 @@
       "dev": true,
       "requires": {
         "package-json": "1.2.0"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
       }
     },
     "levn": {
@@ -2317,6 +2589,18 @@
         "lodash.isarray": "3.0.4"
       }
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
     "lodash.random": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.random/-/lodash.random-3.2.0.tgz",
@@ -2357,6 +2641,22 @@
         "cli-cursor": "1.0.2"
       }
     },
+    "loglevel": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
+      "integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80=",
+      "dev": true
+    },
+    "loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "loglevel": "1.4.1"
+      }
+    },
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
@@ -2381,6 +2681,21 @@
         "miniget": "1.0.0"
       }
     },
+    "make-plural": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz",
+      "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0"
+      }
+    },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
     "map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
@@ -2391,6 +2706,50 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "messageformat": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-1.0.2.tgz",
+      "integrity": "sha1-kI9GkfKf8o2uNcRUNqJM/5NAI4g=",
+      "dev": true,
+      "requires": {
+        "glob": "7.0.6",
+        "make-plural": "3.0.6",
+        "messageformat-parser": "1.1.0",
+        "nopt": "3.0.6",
+        "reserved-words": "0.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.0"
+          }
+        }
+      }
+    },
+    "messageformat-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-1.1.0.tgz",
+      "integrity": "sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA==",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -2691,6 +3050,15 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -2893,6 +3261,232 @@
       "integrity": "sha1-WdrcaDNF7GuI+IuU7Urn4do5S/4=",
       "dev": true
     },
+    "prettier-eslint": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-6.4.2.tgz",
+      "integrity": "sha1-m6/ZVJ4IJzlsdYSOjb62VSW5CW4=",
+      "dev": true,
+      "requires": {
+        "common-tags": "1.4.0",
+        "dlv": "1.1.0",
+        "eslint": "3.19.0",
+        "indent-string": "3.2.0",
+        "lodash.merge": "4.6.0",
+        "loglevel-colored-level-prefix": "1.0.0",
+        "prettier": "1.5.3",
+        "pretty-format": "20.0.3",
+        "require-relative": "0.8.7"
+      },
+      "dependencies": {
+        "eslint": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+          "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.8",
+            "doctrine": "2.0.0",
+            "escope": "3.6.0",
+            "espree": "3.4.3",
+            "esquery": "1.0.0",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "glob": "7.1.2",
+            "globals": "9.18.0",
+            "ignore": "3.3.3",
+            "imurmurhash": "0.1.4",
+            "inquirer": "0.12.0",
+            "is-my-json-valid": "2.16.0",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.9.1",
+            "json-stable-stringify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "1.2.1",
+            "progress": "1.1.8",
+            "require-uncached": "1.0.3",
+            "shelljs": "0.7.8",
+            "strip-bom": "3.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "3.8.3",
+            "text-table": "0.2.0",
+            "user-home": "2.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.1.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.4",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+          "dev": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+          "dev": true
+        },
+        "table": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "ajv-keywords": "1.5.1",
+            "chalk": "1.1.3",
+            "lodash": "4.17.4",
+            "slice-ansi": "0.0.4",
+            "string-width": "2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "prettier-eslint-cli": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-4.1.1.tgz",
+      "integrity": "sha1-smMOMaw7M3ns8CwTD1shnASgvDw=",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "babel-runtime": "6.25.0",
+        "boolify": "1.0.1",
+        "camelcase-keys": "4.1.0",
+        "chalk": "1.1.3",
+        "common-tags": "1.4.0",
+        "find-up": "2.1.0",
+        "get-stdin": "5.0.1",
+        "glob": "7.1.2",
+        "ignore": "3.3.3",
+        "indent-string": "3.2.0",
+        "lodash.memoize": "4.1.2",
+        "loglevel-colored-level-prefix": "1.0.0",
+        "messageformat": "1.0.2",
+        "prettier-eslint": "6.4.2",
+        "rxjs": "5.4.2",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
+      }
+    },
+    "pretty-format": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
+      "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -2933,6 +3527,12 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
       "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
@@ -3138,6 +3738,40 @@
         }
       }
     },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "dev": true
+    },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
@@ -3239,10 +3873,28 @@
         "lodash": "4.17.4"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
     "require-from-string": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
       "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
     "require-uncached": {
@@ -3254,6 +3906,12 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "reserved-words": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz",
+      "integrity": "sha1-b3wV5eVhTFDalhYw2kat3IfAzvI=",
+      "dev": true
     },
     "resolve": {
       "version": "1.4.0",
@@ -3373,6 +4031,12 @@
         "semver": "5.4.1"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -3398,6 +4062,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -3833,6 +4508,15 @@
         }
       }
     },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3883,11 +4567,27 @@
         "isexe": "2.0.0"
       }
     },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "dev": true
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -3933,11 +4633,123 @@
         "os-homedir": "1.0.2"
       }
     },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        }
+      }
     },
     "ytdl-core": {
       "version": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start": "node ./src/app.js",
     "dev": "nodemon --watch src ./src/app.js",
     "precommit": "lint-staged",
-    "lint": "eslint . --ext .js"
+    "lint": "eslint --ext .js",
+    "lint:all": "eslint . --ext .js"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --write",
+      "prettier-eslint --write",
       "eslint . --ext .js --fix",
       "git add"
     ]
@@ -50,9 +50,11 @@
     "eslint": "^4.3.0",
     "eslint-config-airbnb-base": "^11.3.1",
     "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-prettier": "^2.1.2",
     "husky": "^0.14.3",
     "lint-staged": "^4.0.2",
     "nodemon": "^1.11.0",
-    "prettier": "^1.5.3"
+    "prettier": "^1.5.3",
+    "prettier-eslint-cli": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --write",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "lint-staged": {
     "*.js": [
+      "prettier --write",
+      "eslint . --ext .js --fix",
       "git add"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "node ./src/app.js",
     "dev": "nodemon --watch src ./src/app.js",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "lint": "eslint . --ext .js"
   },
   "lint-staged": {
     "*.js": [
@@ -44,6 +45,9 @@
     "ytdl-core": "^0.15.0"
   },
   "devDependencies": {
+    "eslint": "^4.3.0",
+    "eslint-config-airbnb-base": "^11.3.1",
+    "eslint-plugin-import": "^2.7.0",
     "husky": "^0.14.3",
     "lint-staged": "^4.0.2",
     "nodemon": "^1.11.0",

--- a/src/app.js
+++ b/src/app.js
@@ -44,13 +44,13 @@ if (!process.env.JUKEBOX_NO_WEB_UI) {
 }
 
 // define broadcast function to websocket
-app.ws.broadcast = (data) => {
-  for (const client of app.ws.server.clients) {
+app.ws.broadcast = data => {
+  app.ws.server.clients.forEach(client => {
     if (client.readyState === 1) {
       // websocket connection is open
       client.send(data);
     }
-  }
+  });
 };
 
 ev.on(
@@ -61,13 +61,13 @@ ev.on(
 
     // save status
     player_status_store.write_sync(status, {
-      pretty: process.env.NODE_ENV !== 'production',
+      pretty: process.env.NODE_ENV !== 'production'
     });
   }, 200),
 );
 
 // websocket connection
-app.ws.use(socket_route.get('/socket', (ctx) => {}));
+app.ws.use(socket_route.get('/socket', () => {}));
 
 app.use(router.routes());
 app.use(router.allowedMethods());

--- a/src/app.js
+++ b/src/app.js
@@ -63,7 +63,7 @@ ev.on(
     playerStatusStore.writeSync(status, {
       pretty: process.env.NODE_ENV !== 'production'
     });
-  }, 200),
+  }, 200)
 );
 
 // websocket connection

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 const Koa = require('koa');
 const serve = require('koa-static');
-const socket_route = require('koa-route');
+const socketRoute = require('koa-route');
 const mount = require('koa-mount');
 const bodyParser = require('koa-bodyparser');
 const path = require('path');
@@ -25,15 +25,15 @@ const player = new Player(playlist, ev);
 // load status
 const PlayerStatusStore = require('./player_status_store.js');
 
-const player_status_store = new PlayerStatusStore();
-if (player_status_store.exists_sync()) {
-  player.set_status(player_status_store.read_sync());
+const playerStatusStore = new PlayerStatusStore();
+if (playerStatusStore.existsSync()) {
+  player.setStatus(playerStatusStore.readSync());
 }
 
 const Router = require('./router');
 
 const router = new Router();
-router.all_bind(player, playlist);
+router.allBind(player, playlist);
 
 // use body parser
 app.use(bodyParser());
@@ -56,18 +56,18 @@ app.ws.broadcast = data => {
 ev.on(
   'update-status',
   throttle(() => {
-    const status = player.fetch_status();
+    const status = player.fetchStatus();
     app.ws.broadcast(JSON.stringify(status));
 
     // save status
-    player_status_store.write_sync(status, {
+    playerStatusStore.writeSync(status, {
       pretty: process.env.NODE_ENV !== 'production'
     });
   }, 200),
 );
 
 // websocket connection
-app.ws.use(socket_route.get('/socket', () => {}));
+app.ws.use(socketRoute.get('/socket', () => {}));
 
 app.use(router.routes());
 app.use(router.allowedMethods());

--- a/src/controller/player_controller.js
+++ b/src/controller/player_controller.js
@@ -10,13 +10,13 @@ module.exports = class PlayerController {
 
   async next(ctx) {
     this.player.destroy();
-    this.player.start_next();
+    this.player.startNext();
     ctx.status = 200;
   }
 
   async prev(ctx) {
     this.player.destroy();
-    this.player.start_prev();
+    this.player.startPrev();
     ctx.status = 200;
   }
 
@@ -25,44 +25,44 @@ module.exports = class PlayerController {
     ctx.status = 200;
   }
 
-  async one_loop_on(ctx) {
-    this.player.set_one_loop(true);
+  async oneLoopOn(ctx) {
+    this.player.setOneLoop(true);
     ctx.status = 200;
   }
 
-  async one_loop_off(ctx) {
-    this.player.set_one_loop(false);
+  async oneLoopOff(ctx) {
+    this.player.setOneLoop(false);
     ctx.status = 200;
   }
 
-  async playlist_loop_on(ctx) {
-    this.player.set_playlist_loop(true);
+  async playlistLoopOn(ctx) {
+    this.player.setPlaylistLoop(true);
     ctx.status = 200;
   }
 
-  async playlist_loop_off(ctx) {
-    this.player.set_playlist_loop(false);
+  async playlistLoopOff(ctx) {
+    this.player.setPlaylistLoop(false);
     ctx.status = 200;
   }
 
-  async shuffle_mode_on(ctx) {
-    this.player.set_shuffle_mode(true);
+  async shuffleModeOn(ctx) {
+    this.player.setShuffleMode(true);
     ctx.status = 200;
   }
 
-  async shuffle_mode_off(ctx) {
-    this.player.set_shuffle_mode(false);
+  async shuffleModeOff(ctx) {
+    this.player.setShuffleMode(false);
     ctx.status = 200;
   }
 
   async status(ctx) {
-    ctx.body = this.player.fetch_status();
+    ctx.body = this.player.fetchStatus();
     ctx.status = 200;
   }
 
   async seek(ctx) {
     this.player.destroy();
-    this.player.start_specific(Number(ctx.params.index));
+    this.player.startSpecific(Number(ctx.params.index));
     ctx.status = 200;
   }
 };

--- a/src/controller/playlist_controller.js
+++ b/src/controller/playlist_controller.js
@@ -1,4 +1,4 @@
-const Track = require("../track");
+const Track = require('../track');
 
 module.exports = class PlaylistController {
   constructor(player, playlist) {
@@ -29,10 +29,9 @@ module.exports = class PlaylistController {
     if (this.player.shuffle_mode) {
       return {
         shuffle_add: true,
-        shuffle_start_pos: this.player.now_playing_idx + 1
+        shuffle_start_pos: this.player.now_playing_idx + 1,
       };
-    } else {
-      return {};
     }
+    return {};
   }
 };

--- a/src/controller/playlist_controller.js
+++ b/src/controller/playlist_controller.js
@@ -28,8 +28,8 @@ module.exports = class PlaylistController {
   get _addOpts() {
     if (this.player.shuffleMode) {
       return {
-        shuffle_add: true,
-        shuffle_start_pos: this.player.nowPlayingIdx + 1
+        shuffleAdd: true,
+        shuffleStartPos: this.player.nowPlayingIdx + 1
       };
     }
     return {};

--- a/src/controller/playlist_controller.js
+++ b/src/controller/playlist_controller.js
@@ -29,7 +29,7 @@ module.exports = class PlaylistController {
     if (this.player.shuffle_mode) {
       return {
         shuffle_add: true,
-        shuffle_start_pos: this.player.now_playing_idx + 1,
+        shuffle_start_pos: this.player.now_playing_idx + 1
       };
     }
     return {};

--- a/src/controller/playlist_controller.js
+++ b/src/controller/playlist_controller.js
@@ -8,8 +8,8 @@ module.exports = class PlaylistController {
 
   async add(ctx) {
     const links = ctx.request.body;
-    const { tracks, errors } = await Track.create_by_links(links);
-    this.playlist.adds(tracks, this._add_opts);
+    const { tracks, errors } = await Track.createByLinks(links);
+    this.playlist.adds(tracks, this._addOpts);
 
     ctx.body = errors;
     ctx.status = 200;
@@ -25,11 +25,11 @@ module.exports = class PlaylistController {
     ctx.status = 200;
   }
 
-  get _add_opts() {
-    if (this.player.shuffle_mode) {
+  get _addOpts() {
+    if (this.player.shuffleMode) {
       return {
         shuffle_add: true,
-        shuffle_start_pos: this.player.now_playing_idx + 1
+        shuffle_start_pos: this.player.nowPlayingIdx + 1
       };
     }
     return {};

--- a/src/player.js
+++ b/src/player.js
@@ -34,7 +34,10 @@ module.exports = class Player {
 
   start() {
     if (this.now_playing) return;
-    if (this.pausing) return this.resume();
+    if (this.pausing) {
+      this.resume();
+      return;
+    }
 
     this._update_playing_content();
     if (!this.now_playing_content) return;
@@ -91,7 +94,9 @@ module.exports = class Player {
     if (this.audio_stream) this.audio_stream.removeAllListeners('close');
     try {
       this.decoded_stream.unpipe(this.spkr).end();
-    } catch (e) {}
+    } catch (e) {
+      console.error(e);
+    }
     this.now_playing = false;
     this.pausing = false;
     this.ev.emit('update-status');
@@ -135,7 +140,7 @@ module.exports = class Player {
       now_playing: this.now_playing,
       now_playing_idx: this.now_playing_idx,
       now_playing_content: this.now_playing_content,
-      playlist: this.playlist.to_json(),
+      playlist: this.playlist.to_json()
     };
   }
 
@@ -163,7 +168,7 @@ module.exports = class Player {
   _dec_playing_idx() {
     if (this.one_loop) return;
     this.now_playing_idx =
-      (this.now_playing_idx + this.playlist.length() - 1) %
+      (this.now_playing_idx + (this.playlist.length() - 1)) %
       this.playlist.length();
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -92,10 +92,12 @@ module.exports = class Player {
 
   destroy() {
     if (this.audioStream) this.audioStream.removeAllListeners('close');
-    try {
-      this.decodedStream.unpipe(this.spkr).end();
-    } catch (e) {
-      console.error(e);
+    if (this.decodedStream) {
+      try {
+        this.decodedStream.unpipe(this.spkr).end();
+      } catch (e) {
+        console.error(e);
+      }
     }
     this.nowPlaying = false;
     this.pausing = false;
@@ -120,9 +122,7 @@ module.exports = class Player {
 
       // current playing content moves to top if playing music
       if (this.nowPlaying) {
-        const nowContentIdx = this.playlist.queue.indexOf(
-          this.nowPlayingContent,
-        );
+        const nowContentIdx = this.playlist.queue.indexOf(this.nowPlayingContent);
         if (nowContentIdx) {
           this.playlist.queue.splice(nowContentIdx, 1);
           this.playlist.queue.unshift(this.nowPlayingContent);
@@ -168,8 +168,7 @@ module.exports = class Player {
   _decPlayingIdx() {
     if (this.oneLoop) return;
     this.nowPlayingIdx =
-      (this.nowPlayingIdx + (this.playlist.length() - 1)) %
-      this.playlist.length();
+      (this.nowPlayingIdx + (this.playlist.length() - 1)) % this.playlist.length();
   }
 
   _updatePlayingContent(playContent = null) {

--- a/src/player.js
+++ b/src/player.js
@@ -1,7 +1,7 @@
-const Playlist = require("./playlist.js");
-const Provider = require("./provider");
-const speaker = require("speaker");
-const decoder = require("lame").Decoder;
+const Playlist = require('./playlist.js');
+const Provider = require('./provider');
+const speaker = require('speaker');
+const decoder = require('lame').Decoder;
 
 module.exports = class Player {
   constructor(playlist = new Playlist(), ev) {
@@ -19,7 +19,7 @@ module.exports = class Player {
     this.next_play_content = null;
     this.spkr = null;
 
-    this.playlist.on("removed", ({ index }) => {
+    this.playlist.on('removed', ({ index }) => {
       if (index === this.now_playing_idx) {
         // stop and move playing index to the next music
         this.destroy();
@@ -27,7 +27,7 @@ module.exports = class Player {
       } else if (index < this.now_playing_idx) {
         // adjust playing index
         --this.now_playing_idx;
-        this.ev.emit("update-status");
+        this.ev.emit('update-status');
       }
     });
   }
@@ -77,34 +77,34 @@ module.exports = class Player {
     this.decoded_stream.unpipe(this.spkr);
     this.now_playing = false;
     this.pausing = true;
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   resume() {
     this.pausing = false;
     this.now_playing = true;
     this.decoded_stream.pipe(this.spkr);
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   destroy() {
-    if (this.audio_stream) this.audio_stream.removeAllListeners("close");
+    if (this.audio_stream) this.audio_stream.removeAllListeners('close');
     try {
       this.decoded_stream.unpipe(this.spkr).end();
     } catch (e) {}
     this.now_playing = false;
     this.pausing = false;
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   set_one_loop(value) {
     this.one_loop = !!value;
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   set_playlist_loop(value) {
     this.playlist_loop = !!value;
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   set_shuffle_mode(value) {
@@ -116,7 +116,7 @@ module.exports = class Player {
       // current playing content moves to top if playing music
       if (this.now_playing) {
         const now_content_idx = this.playlist.queue.indexOf(
-          this.now_playing_content
+          this.now_playing_content,
         );
         if (now_content_idx) {
           this.playlist.queue.splice(now_content_idx, 1);
@@ -124,7 +124,7 @@ module.exports = class Player {
         }
       }
     }
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   fetch_status() {
@@ -135,7 +135,7 @@ module.exports = class Player {
       now_playing: this.now_playing,
       now_playing_idx: this.now_playing_idx,
       now_playing_content: this.now_playing_content,
-      playlist: this.playlist.to_json()
+      playlist: this.playlist.to_json(),
     };
   }
 
@@ -175,7 +175,7 @@ module.exports = class Player {
     } else {
       this.now_playing_content = this.playlist.pull(this.now_playing_idx);
     }
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   _play_music() {
@@ -184,15 +184,15 @@ module.exports = class Player {
 
     // audio output to the speaker
     this.now_playing = true;
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
     this.decoded_stream = stream.pipe(decoder());
     this.spkr = speaker();
     this.audio_stream = this.decoded_stream.pipe(this.spkr);
-    this.audio_stream.on("close", () => {
+    this.audio_stream.on('close', () => {
       this.now_playing = false;
       this.pausing = false;
       this.destroy();
-      this.ev.emit("update-status");
+      this.ev.emit('update-status');
       this.start_next();
     });
   }

--- a/src/player_status_store.js
+++ b/src/player_status_store.js
@@ -5,24 +5,24 @@ const ENCODE_TYPE = 'utf8';
 const Track = require('./track');
 
 module.exports = class PlayerStatusStore {
-  read_sync() {
-    const status = JSON.parse(fs.readFileSync(this.store_path, ENCODE_TYPE));
+  readSync() {
+    const status = JSON.parse(fs.readFileSync(this.storePath, ENCODE_TYPE));
     if (status.playlist) {
       status.playlist = status.playlist.map(x => new Track(x));
     }
     return status;
   }
 
-  write_sync(content, { pretty = false } = {}) {
+  writeSync(content, { pretty = false } = {}) {
     const data = JSON.stringify(content, null, pretty ? '  ' : null);
-    fs.writeFileSync(this.store_path, data, ENCODE_TYPE);
+    fs.writeFileSync(this.storePath, data, ENCODE_TYPE);
   }
 
-  exists_sync() {
-    return fs.existsSync(this.store_path);
+  existsSync() {
+    return fs.existsSync(this.storePath);
   }
 
-  static get store_path() {
-    return path.join(__dirname, '..', 'store', 'player_status.json');
+  static get storePath() {
+    return path.join(__dirname, '..', 'store', 'playerStatus.json');
   }
 };

--- a/src/player_status_store.js
+++ b/src/player_status_store.js
@@ -22,7 +22,7 @@ module.exports = class PlayerStatusStore {
     return fs.existsSync(this.store_path);
   }
 
-  get store_path() {
+  static get store_path() {
     return path.join(__dirname, '..', 'store', 'player_status.json');
   }
 };

--- a/src/player_status_store.js
+++ b/src/player_status_store.js
@@ -1,7 +1,8 @@
-const fs = require("fs");
-const path = require("path");
-const ENCODE_TYPE = "utf8";
-const Track = require("./track");
+const fs = require('fs');
+const path = require('path');
+
+const ENCODE_TYPE = 'utf8';
+const Track = require('./track');
 
 module.exports = class PlayerStatusStore {
   read_sync() {
@@ -13,7 +14,7 @@ module.exports = class PlayerStatusStore {
   }
 
   write_sync(content, { pretty = false } = {}) {
-    const data = JSON.stringify(content, null, pretty ? "  " : null);
+    const data = JSON.stringify(content, null, pretty ? '  ' : null);
     fs.writeFileSync(this.store_path, data, ENCODE_TYPE);
   }
 
@@ -22,6 +23,6 @@ module.exports = class PlayerStatusStore {
   }
 
   get store_path() {
-    return path.join(__dirname, "..", "store", "player_status.json");
+    return path.join(__dirname, '..', 'store', 'player_status.json');
   }
 };

--- a/src/player_status_store.js
+++ b/src/player_status_store.js
@@ -6,7 +6,7 @@ const Track = require('./track');
 
 module.exports = class PlayerStatusStore {
   readSync() {
-    const status = JSON.parse(fs.readFileSync(this.storePath, ENCODE_TYPE));
+    const status = JSON.parse(fs.readFileSync(this.constructor.storePath, ENCODE_TYPE));
     if (status.playlist) {
       status.playlist = status.playlist.map(x => new Track(x));
     }
@@ -15,14 +15,14 @@ module.exports = class PlayerStatusStore {
 
   writeSync(content, { pretty = false } = {}) {
     const data = JSON.stringify(content, null, pretty ? '  ' : null);
-    fs.writeFileSync(this.storePath, data, ENCODE_TYPE);
+    fs.writeFileSync(this.constructor.storePath, data, ENCODE_TYPE);
   }
 
   existsSync() {
-    return fs.existsSync(this.storePath);
+    return fs.existsSync(this.constructor.storePath);
   }
 
   static get storePath() {
-    return path.join(__dirname, '..', 'store', 'playerStatus.json');
+    return path.join(__dirname, '..', 'store', 'player_status.json');
   }
 };

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,7 +1,7 @@
-const ytdl = require("ytdl-core");
-const shuffle = require("lodash.shuffle");
-const random = require("lodash.random");
-const EventEmitter = require("events").EventEmitter;
+const ytdl = require('ytdl-core');
+const shuffle = require('lodash.shuffle');
+const random = require('lodash.random');
+const EventEmitter = require('events').EventEmitter;
 
 module.exports = class Playlist extends EventEmitter {
   constructor(ev, queue = []) {
@@ -25,7 +25,7 @@ module.exports = class Playlist extends EventEmitter {
 
   dequeue() {
     this.queue.shift();
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   pull_all() {
@@ -46,23 +46,23 @@ module.exports = class Playlist extends EventEmitter {
     } else {
       this.queue.splice(pos, 0, content);
     }
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   replace(queue = []) {
     this.queue = queue;
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   remove(index) {
     this.queue.splice(index, 1);
-    this.ev.emit("update-status");
-    this.emit("removed", { index });
+    this.ev.emit('update-status');
+    this.emit('removed', { index });
   }
 
   shuffle() {
     this.queue = shuffle(this.queue);
-    this.ev.emit("update-status");
+    this.ev.emit('update-status');
   }
 
   length() {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,4 +1,3 @@
-const ytdl = require('ytdl-core');
 const shuffle = require('lodash.shuffle');
 const random = require('lodash.random');
 const EventEmitter = require('events').EventEmitter;
@@ -34,7 +33,7 @@ module.exports = class Playlist extends EventEmitter {
 
   pull(idx = 0) {
     if (this.is_empty()) {
-      return;
+      return null;
     }
 
     return this.queue[idx];

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -9,13 +9,13 @@ module.exports = class Playlist extends EventEmitter {
     this.queue = queue;
   }
 
-  adds(tracks = [], { shuffle_add = false, shuffle_start_pos = 0 } = {}) {
-    tracks.map(track => this.add(track, { shuffle_add, shuffle_start_pos }));
+  adds(tracks = [], { shuffleAdd = false, shuffleStartPos = 0 } = {}) {
+    tracks.map(track => this.add(track, { shuffleAdd, shuffleStartPos }));
   }
 
-  add(track, { shuffle_add = false, shuffle_start_pos = 0 } = {}) {
-    if (shuffle_add) {
-      const pos = random(shuffle_start_pos, this.queue.length);
+  add(track, { shuffleAdd = false, shuffleStartPos = 0 } = {}) {
+    if (shuffleAdd) {
+      const pos = random(shuffleStartPos, this.queue.length);
       this.push(track, pos);
     } else {
       this.push(track);
@@ -27,12 +27,12 @@ module.exports = class Playlist extends EventEmitter {
     this.ev.emit('update-status');
   }
 
-  pull_all() {
+  pullAll() {
     return this.queue;
   }
 
   pull(idx = 0) {
-    if (this.is_empty()) {
+    if (this.isEmpty()) {
       return null;
     }
 
@@ -68,11 +68,11 @@ module.exports = class Playlist extends EventEmitter {
     return this.queue.length;
   }
 
-  is_empty() {
+  isEmpty() {
     return this.queue.length === 0;
   }
 
-  to_json() {
-    return this.queue.map(x => x.to_json());
+  toJson() {
+    return this.queue.map(x => x.toJson());
   }
 };

--- a/src/provider/index.js
+++ b/src/provider/index.js
@@ -4,11 +4,11 @@ const youtube = require('./youtube.js');
 providers.push(youtube);
 
 module.exports = {
-  find_by_link(link) {
+  findByLink(link) {
     return providers.find(provider => provider.pattern.test(link));
   },
 
-  find_by_name(name) {
+  findByName(name) {
     return providers.find(provider => provider.name === name);
   },
 

--- a/src/provider/index.js
+++ b/src/provider/index.js
@@ -1,5 +1,6 @@
 const providers = [];
-const youtube = require("./youtube.js");
+const youtube = require('./youtube.js');
+
 providers.push(youtube);
 
 module.exports = {
@@ -13,5 +14,5 @@ module.exports = {
 
   get providers() {
     return providers;
-  }
+  },
 };

--- a/src/provider/index.js
+++ b/src/provider/index.js
@@ -14,5 +14,5 @@ module.exports = {
 
   get providers() {
     return providers;
-  },
+  }
 };

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -17,7 +17,7 @@ module.exports = {
     'sddefault',
     'hqdefault',
     'mqdefault',
-    'default',
+    'default'
   ],
 
   get_id(link) {
@@ -27,7 +27,7 @@ module.exports = {
   async get_thumbnail_link(link) {
     // Don't use `for of` because of serial processing
     const uris = await Promise.all(
-      this.size_list.map(async (size) => {
+      this.size_list.map(async size => {
         const uri = `http://i.ytimg.com/vi/${this.get_id(link)}/${size}.jpg`;
         try {
           await memorized_request({ method: 'HEAD', uri });
@@ -64,7 +64,7 @@ module.exports = {
   create_stream(link) {
     const opts = {
       filter: 'audioonly',
-      quality: 'lowest',
+      quality: 'lowest'
     };
 
     const audio = ytdl(link, opts);
@@ -73,5 +73,5 @@ module.exports = {
     const stream = new Stream.PassThrough();
     ffmpeg.format('mp3').pipe(stream);
     return stream;
-  },
+  }
 };

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -12,13 +12,7 @@ const memorizedYtdlGetInfo = memorize(ytdl.getInfo.bind(ytdl), CACHE_TIME);
 module.exports = {
   name: 'youtube',
   pattern: /https?:\/\/(www\.)?youtu(be\.com\/watch\?v=|\.be\/)(.+)/,
-  size_list: [
-    'maxresdefault',
-    'sddefault',
-    'hqdefault',
-    'mqdefault',
-    'default'
-  ],
+  size_list: ['maxresdefault', 'sddefault', 'hqdefault', 'mqdefault', 'default'],
 
   get_id(link) {
     return this.pattern.exec(link)[3];
@@ -35,7 +29,7 @@ module.exports = {
         } catch (e) {
           return null;
         }
-      }),
+      })
     );
 
     return uris.find(Boolean) || null;
@@ -52,7 +46,7 @@ module.exports = {
   async getLengthSeconds(link) {
     const info = await this._getInfo(link);
     if (!info) return null;
-    return info.lengthSeconds;
+    return info.length_seconds;
   },
 
   async getTitle(link) {

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -6,8 +6,8 @@ const memorize = require('promise-memorize');
 
 const CACHE_TIME = Number(process.env.JUKEBOX_CACHE_TIME || 60 * 1000);
 
-const memorized_request = memorize(request, CACHE_TIME);
-const memorized_ytdl_get_info = memorize(ytdl.getInfo.bind(ytdl), CACHE_TIME);
+const memorizedRequest = memorize(request, CACHE_TIME);
+const memorizedYtdlGetInfo = memorize(ytdl.getInfo.bind(ytdl), CACHE_TIME);
 
 module.exports = {
   name: 'youtube',
@@ -24,13 +24,13 @@ module.exports = {
     return this.pattern.exec(link)[3];
   },
 
-  async get_thumbnail_link(link) {
+  async getThumbnailLink(link) {
     // Don't use `for of` because of serial processing
     const uris = await Promise.all(
       this.size_list.map(async size => {
         const uri = `http://i.ytimg.com/vi/${this.get_id(link)}/${size}.jpg`;
         try {
-          await memorized_request({ method: 'HEAD', uri });
+          await memorizedRequest({ method: 'HEAD', uri });
           return uri;
         } catch (e) {
           return null;
@@ -41,27 +41,27 @@ module.exports = {
     return uris.find(Boolean) || null;
   },
 
-  async _get_info(link) {
+  async _getInfo(link) {
     try {
-      return await memorized_ytdl_get_info(link);
+      return await memorizedYtdlGetInfo(link);
     } catch (e) {
       return null;
     }
   },
 
-  async get_length_seconds(link) {
-    const info = await this._get_info(link);
+  async getLengthSeconds(link) {
+    const info = await this._getInfo(link);
     if (!info) return null;
-    return info.length_seconds;
+    return info.lengthSeconds;
   },
 
-  async get_title(link) {
-    const info = await this._get_info(link);
+  async getTitle(link) {
+    const info = await this._getInfo(link);
     if (!info) return null;
     return info.title;
   },
 
-  create_stream(link) {
+  createStream(link) {
     const opts = {
       filter: 'audioonly',
       quality: 'lowest'

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -12,17 +12,17 @@ const memorizedYtdlGetInfo = memorize(ytdl.getInfo.bind(ytdl), CACHE_TIME);
 module.exports = {
   name: 'youtube',
   pattern: /https?:\/\/(www\.)?youtu(be\.com\/watch\?v=|\.be\/)(.+)/,
-  size_list: ['maxresdefault', 'sddefault', 'hqdefault', 'mqdefault', 'default'],
+  sizeList: ['maxresdefault', 'sddefault', 'hqdefault', 'mqdefault', 'default'],
 
-  get_id(link) {
+  getId(link) {
     return this.pattern.exec(link)[3];
   },
 
   async getThumbnailLink(link) {
     // Don't use `for of` because of serial processing
     const uris = await Promise.all(
-      this.size_list.map(async size => {
-        const uri = `http://i.ytimg.com/vi/${this.get_id(link)}/${size}.jpg`;
+      this.sizeList.map(async size => {
+        const uri = `http://i.ytimg.com/vi/${this.getId(link)}/${size}.jpg`;
         try {
           await memorizedRequest({ method: 'HEAD', uri });
           return uri;

--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -1,8 +1,8 @@
-const ytdl = require("ytdl-core");
-const FFmpeg = require("fluent-ffmpeg");
-const Stream = require("stream");
-const request = require("request-promise");
-const memorize = require("promise-memorize");
+const ytdl = require('ytdl-core');
+const FFmpeg = require('fluent-ffmpeg');
+const Stream = require('stream');
+const request = require('request-promise');
+const memorize = require('promise-memorize');
 
 const CACHE_TIME = Number(process.env.JUKEBOX_CACHE_TIME || 60 * 1000);
 
@@ -10,14 +10,14 @@ const memorized_request = memorize(request, CACHE_TIME);
 const memorized_ytdl_get_info = memorize(ytdl.getInfo.bind(ytdl), CACHE_TIME);
 
 module.exports = {
-  name: "youtube",
+  name: 'youtube',
   pattern: /https?:\/\/(www\.)?youtu(be\.com\/watch\?v=|\.be\/)(.+)/,
   size_list: [
-    "maxresdefault",
-    "sddefault",
-    "hqdefault",
-    "mqdefault",
-    "default"
+    'maxresdefault',
+    'sddefault',
+    'hqdefault',
+    'mqdefault',
+    'default',
   ],
 
   get_id(link) {
@@ -27,15 +27,15 @@ module.exports = {
   async get_thumbnail_link(link) {
     // Don't use `for of` because of serial processing
     const uris = await Promise.all(
-      this.size_list.map(async size => {
+      this.size_list.map(async (size) => {
         const uri = `http://i.ytimg.com/vi/${this.get_id(link)}/${size}.jpg`;
         try {
-          await memorized_request({ method: "HEAD", uri });
+          await memorized_request({ method: 'HEAD', uri });
           return uri;
         } catch (e) {
           return null;
         }
-      })
+      }),
     );
 
     return uris.find(Boolean) || null;
@@ -63,15 +63,15 @@ module.exports = {
 
   create_stream(link) {
     const opts = {
-      filter: "audioonly",
-      quality: "lowest"
+      filter: 'audioonly',
+      quality: 'lowest',
     };
 
     const audio = ytdl(link, opts);
     const ffmpeg = new FFmpeg(audio);
 
     const stream = new Stream.PassThrough();
-    ffmpeg.format("mp3").pipe(stream);
+    ffmpeg.format('mp3').pipe(stream);
     return stream;
-  }
+  },
 };

--- a/src/router.js
+++ b/src/router.js
@@ -3,14 +3,14 @@ const PlayerController = require('./controller/player_controller');
 const PlaylistController = require('./controller/playlist_controller');
 
 module.exports = class Router extends KoaRouter {
-  all_bind(player, playlist) {
+  allBind(player, playlist) {
     this.player = player;
     this.playlist = playlist;
-    this.bind_player(player);
-    this.bind_playlist(player, playlist);
+    this.bindPlayer(player);
+    this.bindPlaylist(player, playlist);
   }
 
-  bind_player(player) {
+  bindPlayer(player) {
     const c = new PlayerController(player);
     this.player_controller = c;
 
@@ -20,15 +20,15 @@ module.exports = class Router extends KoaRouter {
     this.post('/player/next', c.next.bind(c));
     this.post('/player/prev', c.prev.bind(c));
     this.post('/player/seek/:index', c.seek.bind(c));
-    this.post('/player/loop/one/on', c.one_loop_on.bind(c));
-    this.post('/player/loop/one/off', c.one_loop_off.bind(c));
-    this.post('/player/loop/playlist/on', c.playlist_loop_on.bind(c));
-    this.post('/player/loop/playlist/off', c.playlist_loop_off.bind(c));
-    this.post('/player/loop/shuffle/on', c.shuffle_mode_on.bind(c));
-    this.post('/player/loop/shuffle/off', c.shuffle_mode_off.bind(c));
+    this.post('/player/loop/one/on', c.oneLoopOn.bind(c));
+    this.post('/player/loop/one/off', c.oneLoopOff.bind(c));
+    this.post('/player/loop/playlist/on', c.playlistLoopOn.bind(c));
+    this.post('/player/loop/playlist/off', c.playlistLoopOff.bind(c));
+    this.post('/player/loop/shuffle/on', c.shuffleModeOn.bind(c));
+    this.post('/player/loop/shuffle/off', c.shuffleModeOff.bind(c));
   }
 
-  bind_playlist(player, playlist) {
+  bindPlaylist(player, playlist) {
     const c = new PlaylistController(player, playlist);
     this.playlist_controller = c;
 

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,6 @@
-const KoaRouter = require("koa-router");
-const PlayerController = require("./controller/player_controller");
-const PlaylistController = require("./controller/playlist_controller");
+const KoaRouter = require('koa-router');
+const PlayerController = require('./controller/player_controller');
+const PlaylistController = require('./controller/playlist_controller');
 
 module.exports = class Router extends KoaRouter {
   all_bind(player, playlist) {
@@ -14,26 +14,26 @@ module.exports = class Router extends KoaRouter {
     const c = new PlayerController(player);
     this.player_controller = c;
 
-    this.get("/player/status", c.status.bind(c));
-    this.post("/player/start", c.start.bind(c));
-    this.post("/player/pause", c.pause.bind(c));
-    this.post("/player/next", c.next.bind(c));
-    this.post("/player/prev", c.prev.bind(c));
-    this.post("/player/seek/:index", c.seek.bind(c));
-    this.post("/player/loop/one/on", c.one_loop_on.bind(c));
-    this.post("/player/loop/one/off", c.one_loop_off.bind(c));
-    this.post("/player/loop/playlist/on", c.playlist_loop_on.bind(c));
-    this.post("/player/loop/playlist/off", c.playlist_loop_off.bind(c));
-    this.post("/player/loop/shuffle/on", c.shuffle_mode_on.bind(c));
-    this.post("/player/loop/shuffle/off", c.shuffle_mode_off.bind(c));
+    this.get('/player/status', c.status.bind(c));
+    this.post('/player/start', c.start.bind(c));
+    this.post('/player/pause', c.pause.bind(c));
+    this.post('/player/next', c.next.bind(c));
+    this.post('/player/prev', c.prev.bind(c));
+    this.post('/player/seek/:index', c.seek.bind(c));
+    this.post('/player/loop/one/on', c.one_loop_on.bind(c));
+    this.post('/player/loop/one/off', c.one_loop_off.bind(c));
+    this.post('/player/loop/playlist/on', c.playlist_loop_on.bind(c));
+    this.post('/player/loop/playlist/off', c.playlist_loop_off.bind(c));
+    this.post('/player/loop/shuffle/on', c.shuffle_mode_on.bind(c));
+    this.post('/player/loop/shuffle/off', c.shuffle_mode_off.bind(c));
   }
 
   bind_playlist(player, playlist) {
     const c = new PlaylistController(player, playlist);
     this.playlist_controller = c;
 
-    this.post("/playlist", c.add.bind(c));
-    this.delete("/playlist", c.clear.bind(c));
-    this.delete("/playlist/:index", c.remove.bind(c));
+    this.post('/playlist', c.add.bind(c));
+    this.delete('/playlist', c.clear.bind(c));
+    this.delete('/playlist/:index', c.remove.bind(c));
   }
 };

--- a/src/router.js
+++ b/src/router.js
@@ -12,7 +12,7 @@ module.exports = class Router extends KoaRouter {
 
   bindPlayer(player) {
     const c = new PlayerController(player);
-    this.player_controller = c;
+    this.playerController = c;
 
     this.get('/player/status', c.status.bind(c));
     this.post('/player/start', c.start.bind(c));
@@ -30,7 +30,7 @@ module.exports = class Router extends KoaRouter {
 
   bindPlaylist(player, playlist) {
     const c = new PlaylistController(player, playlist);
-    this.playlist_controller = c;
+    this.playlistController = c;
 
     this.post('/playlist', c.add.bind(c));
     this.delete('/playlist', c.clear.bind(c));

--- a/src/track.js
+++ b/src/track.js
@@ -22,14 +22,12 @@ module.exports = class Track {
       link,
       lengthSeconds: await provider.getLengthSeconds(link),
       title: await provider.getTitle(link),
-      id: provider.get_id(link),
+      id: provider.getId(link),
       thumbnailLink: await provider.getThumbnailLink(link)
     });
 
     if (!track.lengthSeconds) {
-      throw new Error(
-        `This '${providerName}' link can not be played at the moment`,
-      );
+      throw new Error(`This '${providerName}' link can not be played at the moment`);
     }
 
     return track;
@@ -44,10 +42,10 @@ module.exports = class Track {
         } catch (e) {
           return {
             link,
-            err_msg: e && e.message
+            errMsg: e && e.message
           };
         }
-      }),
+      })
     );
 
     return {

--- a/src/track.js
+++ b/src/track.js
@@ -23,7 +23,7 @@ module.exports = class Track {
       length_seconds: await provider.get_length_seconds(link),
       title: await provider.get_title(link),
       id: provider.get_id(link),
-      thumbnail_link: await provider.get_thumbnail_link(link),
+      thumbnail_link: await provider.get_thumbnail_link(link)
     });
 
     if (!track.length_seconds) {
@@ -38,13 +38,13 @@ module.exports = class Track {
   static async create_by_links(links = []) {
     // Don't use `for of` because of serial processing
     const xs = await Promise.all(
-      links.map(async (link) => {
+      links.map(async link => {
         try {
           return await Track.create_by_link(link);
         } catch (e) {
           return {
             link,
-            err_msg: e && e.message,
+            err_msg: e && e.message
           };
         }
       }),
@@ -52,7 +52,7 @@ module.exports = class Track {
 
     return {
       tracks: xs.filter(x => x instanceof Track),
-      errors: xs.filter(x => !(x instanceof Track)),
+      errors: xs.filter(x => !(x instanceof Track))
     };
   }
 
@@ -63,7 +63,7 @@ module.exports = class Track {
       length_seconds: this.length_seconds,
       title: this.title,
       id: this.id,
-      thumbnail_link: this.thumbnail_link,
+      thumbnail_link: this.thumbnail_link
     };
   }
 };

--- a/src/track.js
+++ b/src/track.js
@@ -1,46 +1,46 @@
 const Provider = require('./provider');
 
 module.exports = class Track {
-  constructor({ provider, link, length_seconds, title, id, thumbnail_link }) {
+  constructor({ provider, link, lengthSeconds, title, id, thumbnailLink }) {
     this.provider = provider;
     this.link = link;
-    this.length_seconds = length_seconds;
+    this.lengthSeconds = lengthSeconds;
     this.title = title;
     this.id = id;
-    this.thumbnail_link = thumbnail_link;
+    this.thumbnailLink = thumbnailLink;
   }
 
-  static async create_by_link(link) {
-    const provider = Provider.find_by_link(link);
+  static async createByLink(link) {
+    const provider = Provider.findByLink(link);
     if (!provider) {
       throw new Error('This link belongs to an unsupported provider');
     }
 
-    const provider_name = provider.name;
+    const providerName = provider.name;
     const track = new this({
-      provider: provider_name,
+      provider: providerName,
       link,
-      length_seconds: await provider.get_length_seconds(link),
-      title: await provider.get_title(link),
+      lengthSeconds: await provider.getLengthSeconds(link),
+      title: await provider.getTitle(link),
       id: provider.get_id(link),
-      thumbnail_link: await provider.get_thumbnail_link(link)
+      thumbnailLink: await provider.getThumbnailLink(link)
     });
 
-    if (!track.length_seconds) {
+    if (!track.lengthSeconds) {
       throw new Error(
-        `This '${provider_name}' link can not be played at the moment`,
+        `This '${providerName}' link can not be played at the moment`,
       );
     }
 
     return track;
   }
 
-  static async create_by_links(links = []) {
+  static async createByLinks(links = []) {
     // Don't use `for of` because of serial processing
     const xs = await Promise.all(
       links.map(async link => {
         try {
-          return await Track.create_by_link(link);
+          return await Track.createByLink(link);
         } catch (e) {
           return {
             link,
@@ -56,14 +56,14 @@ module.exports = class Track {
     };
   }
 
-  to_json() {
+  toJson() {
     return {
       provider: this.provider,
       link: this.link,
-      length_seconds: this.length_seconds,
+      lengthSeconds: this.lengthSeconds,
       title: this.title,
       id: this.id,
-      thumbnail_link: this.thumbnail_link
+      thumbnailLink: this.thumbnailLink
     };
   }
 };

--- a/src/track.js
+++ b/src/track.js
@@ -1,4 +1,4 @@
-const Provider = require("./provider");
+const Provider = require('./provider');
 
 module.exports = class Track {
   constructor({ provider, link, length_seconds, title, id, thumbnail_link }) {
@@ -13,7 +13,7 @@ module.exports = class Track {
   static async create_by_link(link) {
     const provider = Provider.find_by_link(link);
     if (!provider) {
-      throw new Error("This link belongs to an unsupported provider");
+      throw new Error('This link belongs to an unsupported provider');
     }
 
     const provider_name = provider.name;
@@ -23,12 +23,12 @@ module.exports = class Track {
       length_seconds: await provider.get_length_seconds(link),
       title: await provider.get_title(link),
       id: provider.get_id(link),
-      thumbnail_link: await provider.get_thumbnail_link(link)
+      thumbnail_link: await provider.get_thumbnail_link(link),
     });
 
     if (!track.length_seconds) {
       throw new Error(
-        `This '${provider_name}' link can not be played at the moment`
+        `This '${provider_name}' link can not be played at the moment`,
       );
     }
 
@@ -38,21 +38,21 @@ module.exports = class Track {
   static async create_by_links(links = []) {
     // Don't use `for of` because of serial processing
     const xs = await Promise.all(
-      links.map(async link => {
+      links.map(async (link) => {
         try {
           return await Track.create_by_link(link);
         } catch (e) {
           return {
             link,
-            err_msg: e && e.message
+            err_msg: e && e.message,
           };
         }
-      })
+      }),
     );
 
     return {
       tracks: xs.filter(x => x instanceof Track),
-      errors: xs.filter(x => !(x instanceof Track))
+      errors: xs.filter(x => !(x instanceof Track)),
     };
   }
 
@@ -63,7 +63,7 @@ module.exports = class Track {
       length_seconds: this.length_seconds,
       title: this.title,
       id: this.id,
-      thumbnail_link: this.thumbnail_link
+      thumbnail_link: this.thumbnail_link,
     };
   }
 };


### PR DESCRIPTION
I added ESLint with airbnb-config-base, and customized ESLint rules based on exists coding policy (see: `.eslintrc.json`).
All JavaScript (and HTML) codes were refactored with ESLint.
And also, I added ESLint check to `lint-staged` (the confliction  betwwen ESLint and Prettier has been solved).

You can run ESLint by `npm run lint:all` or `npm run lint hoge.js`.
If you want to fix codes with ESLint automatically, you can run `npm run lint:all -- -- fix`.


**Important coding policy changes**
- Use **camelCase** as property names instead of snake_case. 
    - You can check whether snake_case property names are remained by `find . -name "*.js" | grep -v node_modules | xargs cat | grep _ | grep -vE '>\w+_\w+<' | grep -v _blank | grep -vE "require\(.*_.*\)" | grep -v '._'`
- Use `' '` (single quotes) instead of `" "` (double quotes).