### PR TITLE
Add eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/coverage


### PR DESCRIPTION
I added `.eslintignore` to ignore `/coverage` in lint.