### PR TITLE
Add clear plasylist modal

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -74,6 +74,7 @@
   <script src="https://unpkg.com/vue"></script>
   <!-- <script src="https://unpkg.com/vue/dist/vue.min.js"></script> -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
+  <script src="js/clear-playlist-modal.js"></script>
   <script src="js/playlist.js"></script>
   <script src="js/player.js"></script>
   <script src="js/links-sender.js"></script>

--- a/assets/js/clear-playlist-modal.js
+++ b/assets/js/clear-playlist-modal.js
@@ -1,0 +1,42 @@
+Vue.component('clear-playlist-modal', {
+  data() {
+    return {
+      opened: false
+    };
+  },
+  methods: {
+    open() {
+      this.opened = true;
+    },
+    close() {
+      this.opened = false;
+    },
+    clearPlaylist() {
+      fetch('/playlist', { method: 'DELETE' });
+    },
+    onSubmit() {
+      this.clearPlaylist();
+      this.close();
+    }
+  },
+
+  template: `
+  <div class="modal clear-playlist-modal" :class="{'is-active': opened}">
+    <div class="modal-background" @click="close"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Confirmation</p>
+        <button class="delete"></button>
+      </header>
+      <section class="modal-card-body">
+        <p><strong>Do you really want to clear the playlist?</strong></p>
+        <p>If you click the clear button, all of tracks in the playlist will be removed.</p>
+      </section>
+      <footer class="modal-card-foot">
+        <a class="button is-danger" @click="onSubmit">Clear</a>
+        <a class="button" @click="close">Cancel</a>
+      </footer>
+    </div>
+  </div>
+  `
+});

--- a/assets/js/clear-playlist-modal.js
+++ b/assets/js/clear-playlist-modal.js
@@ -26,7 +26,7 @@ Vue.component('clear-playlist-modal', {
     <div class="modal-card">
       <header class="modal-card-head">
         <p class="modal-card-title">Confirmation</p>
-        <button class="delete"></button>
+        <button class="delete" @click="close"></button>
       </header>
       <section class="modal-card-body">
         <p><strong>Do you really want to clear the playlist?</strong></p>

--- a/assets/js/playlist.js
+++ b/assets/js/playlist.js
@@ -22,8 +22,8 @@ Vue.component('playlist', {
     isNowPlayingContent(idx) {
       return this.playlist.nowPlayingContent && this.playlist.nowPlayingIdx === idx;
     },
-    playlistClear() {
-      fetch('/playlist', { method: 'DELETE' });
+    openClearPlaylistModal() {
+      this.$refs.clearPlaylistModal.open();
     },
     deleteContent(index) {
       fetch(`/playlist/${index}`, { method: 'DELETE' });
@@ -81,7 +81,7 @@ Vue.component('playlist', {
           title="Clear Playlist"
           class="button playlist-clear-button is-outlined is-fullwidth is-paddingless"
           :disabled="isPlaylistEmpty"
-          @click="playlistClear">
+          @click="openClearPlaylistModal">
           <i class="material-icons icon">delete_sweep</i>
         </button>
       </div>
@@ -91,6 +91,7 @@ Vue.component('playlist', {
         </p>
       </div>
     </div>
+    <clear-playlist-modal ref="clearPlaylistModal"></clear-playlist-modal>
   </div>
   `
 });


### PR DESCRIPTION
This add *Clear Playlist Modal* for confirmation.

![image](https://user-images.githubusercontent.com/6027645/29179158-9c7f9ff4-7e2e-11e7-9918-772b90a1c20a.png)

## Behavior
- *Clear Playlist Modal* will be opened when the clear button in main page is clicked.
- In Clear Playlist Modal, 
    - Playlist will be cleared when the clear button is clicked.
    - The modal will be closed when the close button, the close icon on top right or the background are clicked.