### PR TITLE
Force to exit E2E test and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ I am checking the operation with the latest version of `chrome` and `firefox`.
 |-|-|-|-|
 |JUKEBOX_NO_WEB_UI|''|'yes'|If you set the value, startup with no web UI.|
 |JUKEBOX_PORT|8888|3000|If you set the value, startup with the port of the set value.|
-|JUKEBOX_CACHE_TIME|60000|0|Request cache time (mill seconds)|
+|JUKEBOX_CACHE_TIME|60000|0|Request cache time (mill seconds).|
+
+### for E2E tests
+
+|Parameter|Default|Example|Description|
+|-|-|-|-|
+|E2E_WAIT_TIME|5000|1000|The number of milliseconds to wait to check behavior with our eyes and ears. This can be set as a small value in local tests, but care that a too small value causes bugs.|
+|E2E_PRESENT_WAIT_TIME|30000|60000|The maximum number of milliseconds to wait presentation. Please increase this value when the network speed is slow.|
 
 # Installation
 

--- a/e2e/e2e_helper.js
+++ b/e2e/e2e_helper.js
@@ -1,0 +1,7 @@
+const sampleUrls = require('../tests/helper/sample_urls');
+
+module.exports = {
+  sampleUrls,
+  E2E_WAIT_TIME: Number(process.env.E2E_WAIT_TIME) || 5000,
+  E2E_PRESENT_WAIT_TIME: Number(process.env.E2E_PRESENT_WAIT_TIME) || 30000
+};

--- a/e2e/global.js
+++ b/e2e/global.js
@@ -1,1 +1,33 @@
-module.exports = {};
+const { server, reload, storeHelper } = require('../tests/helper');
+const enableDestroy = require('server-destroy');
+
+enableDestroy(server);
+
+module.exports = {
+  before(done) {
+    storeHelper.makeStub();
+    done();
+  },
+
+  after() {
+    storeHelper.clearStore();
+    server.destroy();
+  },
+
+  beforeEach(done) {
+    storeHelper.clearStore();
+    reload();
+    done();
+  },
+
+  reporter(results, done) {
+    done();
+
+    // force exit
+    const code = results.failed || results.errors ? 1 : 0;
+    setTimeout(() => {
+      console.warn(`Force exit server with code ${code}.`);
+      process.exit(code);
+    }, 3000);
+  }
+};

--- a/e2e/tests/history_test.js
+++ b/e2e/tests/history_test.js
@@ -1,88 +1,86 @@
-require('../../tests/helper');
-const sampleUrls = require('../../tests/helper/sample_urls');
+/* eslint-disable func-names */
 
-const E2E_WAIT_TIME = Number(process.env.E2E_WAIT_TIME) || 5000;
-const PRESENT_WAIT_TIME = 10000;
+const {
+  sampleUrls,
+  E2E_WAIT_TIME: WAIT_TIME,
+  E2E_PRESENT_WAIT_TIME: PRESENT_WAIT_TIME
+} = require('../e2e_helper');
 
 module.exports = {
-  historyTest(browser) {
-    const page = browser.page.index();
+  after(browser) {
+    browser.end();
+  },
 
-    page.navigate().waitForElementVisible('body', PRESENT_WAIT_TIME);
+  'Go to top page': browser => {
+    browser.page.index().navigate().waitForElementVisible('body', PRESENT_WAIT_TIME);
+  },
 
-    // set playlist loop mode
-    page
-      .log('set playlist loop mode')
+  'Set playlist loop mode': browser => {
+    browser.page
+      .index()
       .click('@noLoopButton')
       .waitForElementPresent('@oneLoopButton', PRESENT_WAIT_TIME)
       .click('@oneLoopButton')
       .waitForElementPresent('@playlistLoopButton', PRESENT_WAIT_TIME);
+  },
 
-    // add musics
-    page
-      .log('add musics')
+  'Add musics': browser => {
+    browser.page
+      .index()
       .setValue('@trackUrlField', sampleUrls.join(','))
       .submitForm('@trackSubmitButton')
       .waitForElementPresent('a.playlist-content:nth-child(5)', PRESENT_WAIT_TIME);
+  },
 
-    // open history tab
-    page
-      .log('open history tab')
+  'Open history tab': browser => {
+    browser.page
+      .index()
       .click('@historyTabButton')
       .waitForElementPresent('@history', PRESENT_WAIT_TIME)
       .assert.elementPresent('@history')
       .assert.elementNotPresent('@playlist')
-      .api.pause(E2E_WAIT_TIME);
+      .api.pause(WAIT_TIME);
+  },
 
-    // play music and next twice
-    page
-      .log('play music and next twice')
+  'Play music and play next music twice': browser => {
+    browser.page
+      .index()
       .moveToElement('@playerBlock', 10, 10)
       .click('@playButton')
       .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME)
-      .api.pause(E2E_WAIT_TIME)
+      .api.pause(WAIT_TIME)
       .page.index()
       .click('@nextButton')
-      .api.pause(E2E_WAIT_TIME)
+      .api.pause(WAIT_TIME)
       .page.index()
       .click('@nextButton')
-      .api.pause(E2E_WAIT_TIME)
+      .api.pause(WAIT_TIME)
       .page.index()
       .assert.elementPresent('.history-content:nth-child(3)')
       .assert.containsText('.history-content:nth-child(1) .play-count', '1')
       .assert.containsText('.history-content:nth-child(2) .play-count', '1')
       .assert.containsText('.history-content:nth-child(3) .play-count', '1');
+  },
 
-    // prev music
-    page
-      .log('prev music')
+  'Play prev music': browser => {
+    browser.page
+      .index()
       .click('@prevButton')
-      .api.pause(E2E_WAIT_TIME)
+      .api.pause(WAIT_TIME)
       .page.index()
       .assert.elementPresent('.history-content:nth-child(3)')
       .assert.containsText('.history-content:nth-child(1) .play-count', '2') // sorted
       .assert.containsText('.history-content:nth-child(2) .play-count', '1')
       .assert.containsText('.history-content:nth-child(3) .play-count', '1');
+  },
 
-    // add music from history
-    page
-      .log('add music from history')
+  'Add music from history': browser => {
+    browser.page
+      .index()
       .click('.history-content:nth-child(1) .add-content-button')
       .click('@playlistTabButton')
       .waitForElementPresent('@playlist', PRESENT_WAIT_TIME)
       .waitForElementPresent('a.playlist-content:nth-child(6)', PRESENT_WAIT_TIME)
-      .api.pause(E2E_WAIT_TIME);
-
-    // clear and reset loop mode
-    page
-      .log('clear and reset loop mode')
-      .click('@playlistLoopButton')
-      .click('@openClearModalButton')
-      .waitForElementPresent('@clearModal', PRESENT_WAIT_TIME)
-      .click('@clearButton')
-      .waitForElementNotPresent('a.playlist-content', PRESENT_WAIT_TIME)
-      .api.pause(E2E_WAIT_TIME);
-
-    browser.end();
+      .api.pause(WAIT_TIME);
   }
 };

--- a/e2e/tests/one_loop_test.js
+++ b/e2e/tests/one_loop_test.js
@@ -18,12 +18,18 @@ module.exports = {
   'Add musics': browser => {
     browser.page
       .index()
-      .log('add musics')
       .setValue('@trackUrlField', sampleUrls.join(','))
       .submitForm('@trackSubmitButton')
-      .waitForElementPresent('a.playlist-content:nth-child(5)', PRESENT_WAIT_TIME)
-      .assert.elementPresent('@playButton')
-      .assert.hasPlaylistLength(5)
+      .waitForElementPresent('a.playlist-content:nth-child(5)', 10000)
+      .api.pause(WAIT_TIME);
+  },
+
+  'Set one loop mode': browser => {
+    browser.page
+      .index()
+      .click('@noLoopButton')
+      .waitForElementPresent('@oneLoopButton', PRESENT_WAIT_TIME)
+      .assert.elementPresent('@oneLoopButton')
       .api.pause(WAIT_TIME);
   },
 
@@ -33,7 +39,6 @@ module.exports = {
       .moveToElement('@playerBlock', 10, 10)
       .click('@playButton')
       .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME)
-      .assert.elementPresent('@pauseButton')
       .assert.hasPlaylistLength(5)
       .assert.currentTrackNumEquals(1)
       .api.pause(WAIT_TIME);
@@ -43,9 +48,10 @@ module.exports = {
     browser.page
       .index()
       .click('@nextButton')
-      .waitForElementNotPresent('a.playlist-content:nth-child(5)', PRESENT_WAIT_TIME) // dequeue
+      .api.pause(2000)
+      .page.index()
       .assert.elementPresent('@pauseButton')
-      .assert.hasPlaylistLength(4)
+      .assert.hasPlaylistLength(5)
       .assert.currentTrackNumEquals(1)
       .api.pause(WAIT_TIME);
   },
@@ -54,24 +60,13 @@ module.exports = {
     browser.page.index().assert.cssClassPresent('@prevButton', 'deactivate');
   },
 
-  'Stop music': browser => {
-    browser.page
-      .index()
-      .click('@pauseButton')
-      .waitForElementPresent('@playButton', PRESENT_WAIT_TIME)
-      .assert.elementPresent('@playButton')
-      .assert.hasPlaylistLength(4)
-      .assert.currentTrackNumEquals(1)
-      .api.pause(WAIT_TIME);
-  },
-
   'Play specified music': browser => {
     browser.page
       .index()
       .click('a.playlist-content:nth-child(3)')
       .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME)
       .assert.elementPresent('@pauseButton')
-      .assert.hasPlaylistLength(4)
+      .assert.hasPlaylistLength(5)
       .assert.currentTrackNumEquals(3)
       .api.pause(WAIT_TIME);
   },
@@ -82,19 +77,8 @@ module.exports = {
       .click('a.playlist-content:nth-child(3) i[title=Delete]')
       .waitForElementPresent('@playButton', PRESENT_WAIT_TIME)
       .assert.elementPresent('@playButton')
-      .assert.hasPlaylistLength(3)
+      .assert.hasPlaylistLength(4)
       .assert.currentTrackNumEquals(3)
-      .api.pause(WAIT_TIME);
-  },
-
-  'Clear playlist': browser => {
-    browser.page
-      .index()
-      .click('@openClearModalButton')
-      .waitForElementPresent('@clearModal', PRESENT_WAIT_TIME)
-      .click('@clearButton')
-      .waitForElementNotPresent('a.playlist-content', PRESENT_WAIT_TIME)
-      .assert.hasPlaylistLength(0)
       .api.pause(WAIT_TIME);
   }
 };

--- a/e2e/tests/playlist_loop_test.js
+++ b/e2e/tests/playlist_loop_test.js
@@ -1,0 +1,104 @@
+/* eslint-disable func-names */
+
+const {
+  sampleUrls,
+  E2E_WAIT_TIME: WAIT_TIME,
+  E2E_PRESENT_WAIT_TIME: PRESENT_WAIT_TIME
+} = require('../e2e_helper');
+
+module.exports = {
+  after(browser) {
+    browser.end();
+  },
+
+  'Go to top page': browser => {
+    browser.page.index().navigate().waitForElementVisible('body', PRESENT_WAIT_TIME);
+  },
+
+  'Add musics': browser => {
+    browser.page
+      .index()
+      .setValue('@trackUrlField', sampleUrls.join(','))
+      .submitForm('@trackSubmitButton')
+      .waitForElementPresent('a.playlist-content:nth-child(5)', PRESENT_WAIT_TIME)
+      .api.pause(WAIT_TIME);
+  },
+
+  'Set playlist loop mode': browser => {
+    browser.page
+      .index()
+      .click('@noLoopButton')
+      .waitForElementPresent('@oneLoopButton', PRESENT_WAIT_TIME)
+      .click('@oneLoopButton')
+      .waitForElementPresent('@playlistLoopButton', PRESENT_WAIT_TIME)
+      .assert.elementPresent('@playlistLoopButton')
+      .api.pause(WAIT_TIME);
+  },
+
+  'Play music': browser => {
+    browser.page
+      .index()
+      .moveToElement('@playerBlock', 10, 10)
+      .click('@playButton')
+      .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME)
+      .assert.hasPlaylistLength(5)
+      .assert.currentTrackNumEquals(1)
+      .api.pause(WAIT_TIME);
+  },
+
+  'Play next music': browser => {
+    browser.page
+      .index()
+      .click('@nextButton')
+      .api.pause(2000)
+      .page.index()
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(5)
+      .assert.currentTrackNumEquals(2)
+      .api.pause(WAIT_TIME);
+  },
+
+  'Play prev music': browser => {
+    browser.page
+      .index()
+      .click('@prevButton')
+      .api.pause(2000)
+      .page.index()
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(5)
+      .assert.currentTrackNumEquals(1)
+      .api.pause(WAIT_TIME);
+  },
+
+  'Play last, next and prev musics': browser => {
+    browser.page
+      .index()
+      .click('a.playlist-content:nth-child(5)')
+      .waitForElementPresent(
+        '.playlist-content:nth-child(5) .thumbnail-wrapper i',
+        PRESENT_WAIT_TIME
+      )
+      .assert.currentTrackNumEquals(5)
+      .api.pause(WAIT_TIME)
+      .page.index()
+      .click('@nextButton')
+      .waitForElementPresent(
+        '.playlist-content:nth-child(1) .thumbnail-wrapper i',
+        PRESENT_WAIT_TIME
+      )
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(5)
+      .assert.currentTrackNumEquals(1)
+      .api.pause(WAIT_TIME)
+      .page.index()
+      .click('@prevButton')
+      .waitForElementPresent(
+        '.playlist-content:nth-child(5) .thumbnail-wrapper i',
+        PRESENT_WAIT_TIME
+      )
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(5)
+      .assert.currentTrackNumEquals(5)
+      .api.pause(WAIT_TIME);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "promise-memorize": "^1.1.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
+    "server-destroy": "^1.0.1",
     "speaker": "^0.3.0",
     "ytdl-core": "^0.15.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -79,6 +79,9 @@ if (process.env.JUKEBOX_PORT) {
   port = process.env.JUKEBOX_PORT;
 }
 
-app.listen(port);
+const server = app.listen(port);
 
-module.exports = app;
+module.exports = {
+  app,
+  server
+};

--- a/tests/helper/index.js
+++ b/tests/helper/index.js
@@ -4,10 +4,11 @@ const storeHelper = require('./store_helper');
 storeHelper.clearStore();
 storeHelper.makeStub();
 
-const app = require('../../src/app');
+const { app, server } = require('../../src/app');
 
 module.exports = {
   app,
+  server,
   request: supertest(app),
   storeHelper,
   reload() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,6 +3852,10 @@ semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
+server-destroy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
## Changes
- Fix to force to exit zombie E2E process ( fixed #94 ).
- Add `E2E_PRESENT_WAIT_TIME` environment (default value is 30,000ms).

## Refactorings
- Change values returned from `src/app.js` from `app` to `{app, server}`.
- Add `server` to values returned from `tests/helper/index.js`.
- Create `e2e/e2e_helper.js`.
- Move common E2E process from each test file to `e2e/globals.js`.
- Divide `e2e/tests/index_test.js` into `e2e/tests/{index, one_loop, playlist_loop}_test.js`.
- Divide each E2E test function into several action functions.
- Remove duplicated clear playlist tests in `e2e/tests/{one_loop, playlist_loop, history}_test.js`.
- Fix typos in E2E test.

## New packages
- `server-destroy`