### PR TITLE
Remove unnecessary stream in youtube.js

### DIFF
--- a/src/provider/youtube.js
+++ b/src/provider/youtube.js
@@ -1,6 +1,5 @@
 const ytdl = require('ytdl-core');
 const FFmpeg = require('fluent-ffmpeg');
-const Stream = require('stream');
 const request = require('request-promise');
 const memorize = require('promise-memorize');
 
@@ -63,9 +62,6 @@ module.exports = {
 
     const audio = ytdl(link, opts);
     const ffmpeg = new FFmpeg(audio);
-
-    const stream = new Stream.PassThrough();
-    ffmpeg.format('mp3').pipe(stream);
-    return stream;
+    return ffmpeg.format('mp3').pipe();
   }
 };


### PR DESCRIPTION
> When no stream argument is present, the pipe() method returns a PassThrough stream, which you can pipe to somewhere else (or just listen to events on).
>
> https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#pipestream-options-pipe-the-output-to-a-writable-stream