### PR TITLE
Add E2E test for end of music

### DIFF
--- a/e2e/e2e_helper.js
+++ b/e2e/e2e_helper.js
@@ -1,7 +1,9 @@
 const sampleUrls = require('../tests/helper/sample_urls');
+const shortSampleUrls = require('../tests/helper/short_sample_urls');
 
 module.exports = {
   sampleUrls,
+  shortSampleUrls,
   E2E_WAIT_TIME: Number(process.env.E2E_WAIT_TIME) || 5000,
   E2E_PRESENT_WAIT_TIME: Number(process.env.E2E_PRESENT_WAIT_TIME) || 30000
 };

--- a/e2e/tests/index_test.js
+++ b/e2e/tests/index_test.js
@@ -108,12 +108,11 @@ module.exports = {
     browser.page
       .index()
       .waitForElementNotPresent(
-        '.playlist-content:nth-child(3) .thumbnail-wrapper i',
+        '.playlist-content:nth-child(4) .thumbnail-wrapper i',
         PRESENT_WAIT_TIME
       )
-      .assert.elementPresent('@pauseButton')
-      .assert.hasPlaylistLength(3)
-      .assert.currentTrackNumEquals(-1);
+      .assert.elementPresent('@playButton')
+      .assert.hasPlaylistLength(3);
   },
 
   'Clear playlist': browser => {

--- a/e2e/tests/index_test.js
+++ b/e2e/tests/index_test.js
@@ -2,6 +2,7 @@
 
 const {
   sampleUrls,
+  shortSampleUrls,
   E2E_WAIT_TIME: WAIT_TIME,
   E2E_PRESENT_WAIT_TIME: PRESENT_WAIT_TIME
 } = require('../e2e_helper');
@@ -85,6 +86,34 @@ module.exports = {
       .assert.hasPlaylistLength(3)
       .assert.currentTrackNumEquals(3)
       .api.pause(WAIT_TIME);
+  },
+
+  'Add short music': browser => {
+    browser.page
+      .index()
+      .setValue('@trackUrlField', shortSampleUrls[0])
+      .submitForm('@trackSubmitButton')
+      .waitForElementPresent('a.playlist-content:nth-child(4)', PRESENT_WAIT_TIME)
+      .assert.hasPlaylistLength(4);
+  },
+
+  'Play short music': browser => {
+    browser.page
+      .index()
+      .click('a.playlist-content:nth-child(4)')
+      .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME);
+  },
+
+  'Wait till end': browser => {
+    browser.page
+      .index()
+      .waitForElementNotPresent(
+        '.playlist-content:nth-child(3) .thumbnail-wrapper i',
+        PRESENT_WAIT_TIME
+      )
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(3)
+      .assert.currentTrackNumEquals(-1);
   },
 
   'Clear playlist': browser => {

--- a/e2e/tests/one_loop_test.js
+++ b/e2e/tests/one_loop_test.js
@@ -2,6 +2,7 @@
 
 const {
   sampleUrls,
+  shortSampleUrls,
   E2E_WAIT_TIME: WAIT_TIME,
   E2E_PRESENT_WAIT_TIME: PRESENT_WAIT_TIME
 } = require('../e2e_helper');
@@ -95,5 +96,30 @@ module.exports = {
       .assert.hasPlaylistLength(4)
       .assert.currentTrackNumEquals(3)
       .api.pause(WAIT_TIME);
+  },
+
+  'Add short music': browser => {
+    browser.page
+      .index()
+      .setValue('@trackUrlField', shortSampleUrls[0])
+      .submitForm('@trackSubmitButton')
+      .waitForElementPresent('a.playlist-content:nth-child(5)', PRESENT_WAIT_TIME)
+      .assert.hasPlaylistLength(5);
+  },
+
+  'Play short music': browser => {
+    browser.page
+      .index()
+      .click('a.playlist-content:nth-child(5)')
+      .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME);
+  },
+
+  'Wait till end': browser => {
+    browser
+      .pause(3000)
+      .page.index()
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(5)
+      .assert.currentTrackNumEquals(5);
   }
 };

--- a/e2e/tests/playlist_loop_test.js
+++ b/e2e/tests/playlist_loop_test.js
@@ -2,6 +2,7 @@
 
 const {
   sampleUrls,
+  shortSampleUrls,
   E2E_WAIT_TIME: WAIT_TIME,
   E2E_PRESENT_WAIT_TIME: PRESENT_WAIT_TIME
 } = require('../e2e_helper');
@@ -100,5 +101,33 @@ module.exports = {
       .assert.hasPlaylistLength(5)
       .assert.currentTrackNumEquals(5)
       .api.pause(WAIT_TIME);
+  },
+
+  'Add short music': browser => {
+    browser.page
+      .index()
+      .setValue('@trackUrlField', shortSampleUrls[0])
+      .submitForm('@trackSubmitButton')
+      .waitForElementPresent('a.playlist-content:nth-child(6)', PRESENT_WAIT_TIME)
+      .assert.hasPlaylistLength(6);
+  },
+
+  'Play short music': browser => {
+    browser.page
+      .index()
+      .click('a.playlist-content:nth-child(6)')
+      .waitForElementPresent('@pauseButton', PRESENT_WAIT_TIME);
+  },
+
+  'Wait till end': browser => {
+    browser.page
+      .index()
+      .waitForElementPresent(
+        '.playlist-content:nth-child(1) .thumbnail-wrapper i',
+        PRESENT_WAIT_TIME
+      )
+      .assert.elementPresent('@pauseButton')
+      .assert.hasPlaylistLength(6)
+      .assert.currentTrackNumEquals(1);
   }
 };

--- a/src/player.js
+++ b/src/player.js
@@ -89,7 +89,7 @@ module.exports = class Player extends EventEmitter {
   async startNext() {
     switch (this.status.loopMode) {
       case LoopMode.NONE:
-        this.playlist.dequeue();
+        this.playlist.remove(this.status.nowPlayingIdx);
         await this.start();
         return;
 

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -21,11 +21,6 @@ module.exports = class Playlist extends EventEmitter {
     }
   }
 
-  dequeue() {
-    this.queue.shift();
-    this.emit('updated');
-  }
-
   pullAll() {
     return this.queue;
   }

--- a/tests/helper/short_sample_urls.js
+++ b/tests/helper/short_sample_urls.js
@@ -1,0 +1,4 @@
+module.exports = [
+  'https://www.youtube.com/watch?v=Qy4bP0s5KTE', // 2 seconds
+  'https://www.youtube.com/watch?v=6wby9ZEDj7Q' // 7 seconds
+];


### PR DESCRIPTION
This add E2E test for end of music in all loop mode (fixed #122) using sample URLs of short length video.

I found the dequeue bug during this work, but I fixed it by using `remove` method.
By the fix, `Playlist.dequeue()` is no longer used, so I removed it.