### PR TITLE
Add copied tooltip for reaction of link button

### DIFF
--- a/assets/css/copy-link-button.css
+++ b/assets/css/copy-link-button.css
@@ -6,12 +6,13 @@
   content: "Copied!";
   position: absolute;
   background: #222;
-  border-radius: 5px;
-  top: 26px;
+  border-radius: 7px;
+  right: 26px;
   color: #fff;
-  left: calc(50% - 24px);
+  top: calc(50% - 12px);
   padding: 4px;
   font-size: 0.75em;
+  height: 24px;
   width: 48px;
   text-align: center;
 }
@@ -20,8 +21,8 @@
   content: "";
   position: absolute;
   border: solid;
-  border-color: #222 transparent;
-  border-width: 0 6px 6px 6px;
-  top: 20px;
-  left: calc(50% - 6px);
+  border-color: transparent #222;
+  border-width: 6px 0 6px 6px;
+  right: 20px;
+  top: calc(50% - 6px);
 }

--- a/assets/css/copy-link-button.css
+++ b/assets/css/copy-link-button.css
@@ -1,0 +1,27 @@
+.copy-link-button {
+  position: relative;
+}
+
+.copied-tooltip::after {
+  content: "Copied!";
+  position: absolute;
+  background: #222;
+  border-radius: 5px;
+  top: 26px;
+  color: #fff;
+  left: calc(50% - 24px);
+  padding: 4px;
+  font-size: 0.75em;
+  width: 48px;
+  text-align: center;
+}
+
+.copied-tooltip::before {
+  content: "";
+  position: absolute;
+  border: solid;
+  border-color: #222 transparent;
+  border-width: 0 6px 6px 6px;
+  top: 20px;
+  left: calc(50% - 6px);
+}

--- a/assets/index.html
+++ b/assets/index.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="css/history.css">
   <link rel="stylesheet" href="css/links-sender.css">
   <link rel="stylesheet" href="css/animation-badge.css">
+  <link rel="stylesheet" href="css/copy-link-button.css">
 </head>
 
 <body>
@@ -110,6 +111,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
   <script src="js/animation-badge.js"></script>
+  <script src="js/copy-link-button.js"></script>
   <script src="js/clear-playlist-modal.js"></script>
   <script src="js/history.js"></script>
   <script src="js/playlist.js"></script>

--- a/assets/js/copy-link-button.js
+++ b/assets/js/copy-link-button.js
@@ -1,0 +1,31 @@
+Vue.component('copy-link-button', {
+  props: ['link', 'tooltipDuration'],
+  data() {
+    return {
+      isCopied: false,
+      clipboard: null
+    };
+  },
+  created() {
+    this.clipboard = new Clipboard('.copy-link-button');
+  },
+  methods: {
+    copyUrl(e) {
+      this.clipboard.onClick(e);
+      if (this.tooltipDuration) {
+        this.isCopied = true;
+        setTimeout(() => {
+          this.isCopied = false;
+        }, this.tooltipDuration);
+      }
+    }
+  },
+  template: `
+  <a class="in-content-button copy-link-button"
+     @click.prevent.stop="copyUrl"
+     :data-clipboard-text="link"
+     :class="{'copied-tooltip': isCopied}">
+    <i class="material-icons icon" title="Copy Link">link</i>
+  </a>
+ `
+});

--- a/assets/js/history.js
+++ b/assets/js/history.js
@@ -1,17 +1,6 @@
 Vue.component('history', {
   props: ['data'],
-  data() {
-    return {
-      clipboard: null
-    };
-  },
-  created() {
-    this.clipboard = new Clipboard('.copy-link-button');
-  },
   methods: {
-    copyUrl(e) {
-      this.clipboard.onClick(e);
-    },
     humanizeTime(seconds) {
       const s = seconds % 60;
       const m = Math.floor(seconds / 60) % 60;
@@ -58,9 +47,7 @@ Vue.component('history', {
               {{ humanizeTime(content.track.lengthSeconds) }}
             </div>
             <div class="column is-1 has-text-centered align-self-center is-paddingless-vertical">
-              <a class="is-flex in-content-button copy-link-button" @click.prevent.stop="copyUrl" :data-clipboard-text="content.track.link">
-                <i class="material-icons icon" title="Copy Link">link</i>
-              </a>
+              <copy-link-button class="is-flex" :link="content.track.link" tooltip-duration="1000"></copy-link-button>
             </div>
             <div class="column is-1 has-text-centered align-self-center is-paddingless-vertical">
               <a class="is-flex in-content-button add-content-button" @click.prevent.stop="addContent(idx)">

--- a/assets/js/playlist.js
+++ b/assets/js/playlist.js
@@ -1,17 +1,6 @@
 Vue.component('playlist', {
   props: ['data'],
-  data() {
-    return {
-      clipboard: null
-    };
-  },
-  created() {
-    this.clipboard = new Clipboard('.copy-link-button');
-  },
   methods: {
-    copyUrl(e) {
-      this.clipboard.onClick(e);
-    },
     humanizeTime(seconds) {
       const s = seconds % 60;
       const m = Math.floor(seconds / 60) % 60;
@@ -74,9 +63,7 @@ Vue.component('playlist', {
                   {{ humanizeTime(content.lengthSeconds) }}
                 </div>
                 <div class="column is-1 has-text-centered align-self-center is-paddingless-vertical">
-                  <a class="is-flex in-content-button copy-link-button" @click.prevent.stop="copyUrl" :data-clipboard-text="content.link">
-                    <i class="material-icons icon" title="Copy Link">link</i>
-                  </a>
+                  <copy-link-button class="is-flex" :link="content.link" tooltip-duration="1000"></copy-link-button>
                 </div>
                 <div class="column is-1 has-text-centered align-self-center is-paddingless-vertical">
                   <a class="is-flex in-content-button" @click.prevent.stop="deleteContent(idx)">


### PR DESCRIPTION
This add the reaction of link copy (#120).
The reaction is represented by *tooltip*.
Additionally, I refactored codes by extracting `copy-link-button` component.

Appearance:

![jukebox-copied-tooltip](https://user-images.githubusercontent.com/6027645/29389809-7012139a-8327-11e7-9902-056164c8c44b.gif)
