### PR TITLE
Add seek bar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
   },
   "globals": {
     "Vue": true,
-    "Clipboard": true
+    "Clipboard": true,
+    "Util": true
   },
   "rules": {
     "no-new": "off",

--- a/assets/css/player.css
+++ b/assets/css/player.css
@@ -88,3 +88,20 @@
   /* 24px is bulma's gap. 4:3 */
   min-height: calc((100vw - 24px * 2) * 0.75)
 }
+
+.progressbar-block .seek-time, .progressbar-block .length-time {
+  color: #fff;
+}
+
+.progressbar-block .progress {
+  height: 0.75rem;
+  margin-top: 0.45rem;
+}
+
+.progressbar-block .progress::-webkit-progress-bar {
+  background-color: hsl(0, 0%, 29%)
+}
+
+.progressbar-block .progress::-webkit-progress-value {
+  background-color: hsl(0, 0%, 86%);
+}

--- a/assets/index.html
+++ b/assets/index.html
@@ -110,6 +110,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.6.0/Sortable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
+  <script src="js/util.js"></script>
   <script src="js/animation-badge.js"></script>
   <script src="js/copy-link-button.js"></script>
   <script src="js/clear-playlist-modal.js"></script>

--- a/assets/js/history.js
+++ b/assets/js/history.js
@@ -2,11 +2,7 @@ Vue.component('history', {
   props: ['data'],
   methods: {
     humanizeTime(seconds) {
-      const s = seconds % 60;
-      const m = Math.floor(seconds / 60) % 60;
-      const h = Math.floor(seconds / 3600);
-      const padding = num => `00${num}`.slice(-2);
-      return `${padding(h)}:${padding(m)}:${padding(s)}`;
+      return Util.humanizeTimeFromSeconds(seconds);
     },
     async addContent(idx) {
       try {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,7 +3,8 @@ new Vue({
   data: {
     playerStatus: {},
     history: [],
-    activeTab: 'playlist'
+    activeTab: 'playlist',
+    seekSeconds: 0
   },
   computed: {
     nowPlayingContent() {
@@ -18,7 +19,8 @@ new Vue({
         shuffleMode: this.playerStatus.shuffleMode,
         nowPlayingIdx: this.playerStatus.nowPlayingIdx,
         nowPlayingContent: this.nowPlayingContent,
-        volume: this.playerStatus.volume
+        volume: this.playerStatus.volume,
+        seekSeconds: this.seekSeconds
       };
     },
     bindPlaylist() {
@@ -59,10 +61,14 @@ new Vue({
 
       const history = await fetch('/history');
       this.history = await history.json();
+
+      const seekTime = await fetch('/player/seek/time');
+      this.seekSeconds = (await seekTime.json()).seekSeconds;
     },
     teardown() {
       this.playerStatus = {};
       this.history = [];
+      this.seekSeconds = 0;
     },
     setupSocket() {
       const socket = new WebSocket(`ws://${location.host}/socket`);
@@ -73,6 +79,8 @@ new Vue({
           this.history = data;
         } else if (name === 'update-status') {
           this.playerStatus = data;
+        } else if (name === 'updated-seek') {
+          this.seekSeconds = data.seekSeconds;
         }
       });
       socket.addEventListener('close', () => {

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -79,14 +79,13 @@ Vue.component('player', {
       return player && player.nowPlayingContent && player.nowPlayingContent.lengthSeconds;
     },
     seekSeconds() {
-      console.log(this.seek);
       return this.seek;
     },
     lengthTime() {
-      return '00:00:00';
+      return Util.humanizeTimeFromSeconds(this.lengthSeconds);
     },
     seekTime() {
-      return '00:00:00';
+      return Util.humanizeTimeFromSeconds(this.seekSeconds);
     }
   },
 

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -1,19 +1,6 @@
 Vue.component('player', {
   props: ['player'],
 
-  data() {
-    return {
-      seek: 0
-    };
-  },
-
-  created() {
-    setInterval(() => {
-      this.seek += 1;
-      console.log(this.seek);
-    }, 1000);
-  },
-
   methods: {
     playerStart() {
       fetch('/player/start', { method: 'POST' });
@@ -75,17 +62,13 @@ Vue.component('player', {
       }
     },
     lengthSeconds() {
-      const player = this.player;
-      return player && player.nowPlayingContent && player.nowPlayingContent.lengthSeconds;
-    },
-    seekSeconds() {
-      return this.seek;
+      return this.player.nowPlayingContent && this.player.nowPlayingContent.lengthSeconds;
     },
     lengthTime() {
       return Util.humanizeTimeFromSeconds(this.lengthSeconds);
     },
     seekTime() {
-      return Util.humanizeTimeFromSeconds(this.seekSeconds);
+      return Util.humanizeTimeFromSeconds(Math.floor(this.player.seekSeconds));
     }
   },
 
@@ -132,7 +115,7 @@ Vue.component('player', {
         <div class="columns has-text-centered is-mobile progressbar-block" v-if="player.nowPlayingContent">
           <div class="column is-3 seek-time has-text-right">{{ seekTime }}</div>
           <div class="column is-6 ">
-            <progress class="progress" :value="seekSeconds" :max="lengthSeconds"></progress>
+            <progress class="progress" :value="player.seekSeconds" :max="lengthSeconds"></progress>
           </div>
           <div class="column is-3 length-time has-text-left">{{ lengthTime }}</div>
         </div>

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -1,6 +1,19 @@
 Vue.component('player', {
   props: ['player'],
 
+  data() {
+    return {
+      seek: 0
+    };
+  },
+
+  created() {
+    setInterval(() => {
+      this.seek += 1;
+      console.log(this.seek);
+    }, 1000);
+  },
+
   methods: {
     playerStart() {
       fetch('/player/start', { method: 'POST' });
@@ -60,6 +73,20 @@ Vue.component('player', {
         fetch('/player/volume', { method: 'POST', body, headers });
         // }, 500);
       }
+    },
+    lengthSeconds() {
+      const player = this.player;
+      return player && player.nowPlayingContent && player.nowPlayingContent.lengthSeconds;
+    },
+    seekSeconds() {
+      console.log(this.seek);
+      return this.seek;
+    },
+    lengthTime() {
+      return '00:00:00';
+    },
+    seekTime() {
+      return '00:00:00';
     }
   },
 
@@ -103,6 +130,13 @@ Vue.component('player', {
         </div>
       </div>
       <div class="player-other-controller">
+        <div class="columns has-text-centered is-mobile progressbar-block" v-if="player.nowPlayingContent">
+          <div class="column is-3 seek-time has-text-right">{{ seekTime }}</div>
+          <div class="column is-6 ">
+            <progress class="progress" :value="seekSeconds" :max="lengthSeconds"></progress>
+          </div>
+          <div class="column is-3 length-time has-text-left">{{ lengthTime }}</div>
+        </div>
         <div class="columns has-text-centered is-mobile">
           <div class="column is-2">
             <a @click="restart">

--- a/assets/js/playlist.js
+++ b/assets/js/playlist.js
@@ -2,11 +2,7 @@ Vue.component('playlist', {
   props: ['data'],
   methods: {
     humanizeTime(seconds) {
-      const s = seconds % 60;
-      const m = Math.floor(seconds / 60) % 60;
-      const h = Math.floor(seconds / 3600);
-      const padding = num => `00${num}`.slice(-2);
-      return `${padding(h)}:${padding(m)}:${padding(s)}`;
+      return Util.humanizeTimeFromSeconds(seconds);
     },
     isNowPlayingContent(idx) {
       return this.playlist.nowPlayingContent && this.playlist.nowPlayingIdx === idx;

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -1,0 +1,9 @@
+window.Util = {
+  humanizeTimeFromSeconds(seconds) {
+    const s = seconds % 60;
+    const m = Math.floor(seconds / 60) % 60;
+    const h = Math.floor(seconds / 3600);
+    const padding = num => `00${num}`.slice(-2);
+    return `${padding(h)}:${padding(m)}:${padding(s)}`;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.random": "^3.2.0",
     "lodash.shuffle": "^4.2.0",
+    "lodash.throttle": "^4.1.1",
     "pcm-volume": "^1.0.0",
     "promise-memorize": "^1.1.0",
     "request": "^2.81.0",

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ const mount = require('koa-mount');
 const bodyParser = require('koa-bodyparser');
 const path = require('path');
 const debounce = require('lodash.debounce');
+const throttle = require('lodash.throttle');
 const websockify = require('koa-websocket');
 const favicon = require('koa-favicon');
 const Router = require('./router');
@@ -68,6 +69,18 @@ jukebox.history.on(
     // save history
     jukebox.history.save();
   }, 1000)
+);
+
+jukebox.player.on(
+  'updatedSeek',
+  throttle(({ seekSeconds }) => {
+    app.ws.broadcast(
+      JSON.stringify({
+        name: 'updated-seek',
+        data: { seekSeconds }
+      })
+    );
+  }, 100)
 );
 
 // websocket connection

--- a/src/controller/player_controller.js
+++ b/src/controller/player_controller.js
@@ -56,6 +56,11 @@ module.exports = class PlayerController {
     ctx.status = 200;
   }
 
+  async seekTime(ctx) {
+    ctx.body = { seekSeconds: this.player.seekSeconds };
+    ctx.status = 200;
+  }
+
   async volume(ctx) {
     this.player.setVolume(ctx.request.body.volume);
     ctx.status = 200;

--- a/src/model/player.js
+++ b/src/model/player.js
@@ -71,6 +71,9 @@ module.exports = class Player extends EventEmitter {
         // Call start async to early notify and improve UX
         this.speaker.start(this.nowPlayingStream).catch(e => console.error(e));
         this.speaker.on('stopped', this._onSpeakerStoppedEventBinded);
+        this.speaker.on('updatedSeek', ({ seekSeconds }) =>
+          this.emit('updatedSeek', { seekSeconds })
+        );
         this.status.play();
         this.history.add(this.nowPlayingContent);
         this.emit('updated-status');
@@ -224,6 +227,10 @@ module.exports = class Player extends EventEmitter {
   get nowPlayingContent() {
     const idx = this.status.nowPlayingIdx;
     return idx < this.playlist.length() ? this.playlist.pull(idx) : null;
+  }
+
+  get seekSeconds() {
+    return this.speaker && this.speaker.seekSeconds;
   }
 
   setVolume(vol) {

--- a/src/router.js
+++ b/src/router.js
@@ -21,6 +21,7 @@ module.exports = class Router extends KoaRouter {
     this.post('/player/next', c.next.bind(c));
     this.post('/player/prev', c.prev.bind(c));
     this.post('/player/seek/:index', c.seek.bind(c));
+    this.get('/player/seek/time', c.seekTime.bind(c));
     this.post('/player/volume', c.volume.bind(c));
     this.post('/player/volume/on', c.volumeOn.bind(c));
     this.post('/player/volume/off', c.volumeOff.bind(c));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2597,6 +2597,10 @@ lodash.shuffle@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
This add *seek bar* for #4 .

## View changes
- Add seek bar above player control block.

## API changes
- Add `GET /player/seek/time` which returns `{seekSeconds}`.
- Add `updated-seek` event which returns `{name: 'updated-seek', data: {seekSeconds}}`.

## Package changes
- Add `lodash.throttle` package.

## Refactorings
- Extract `assets/js/util.js` with `humanizeTimeFromSeconds()` method, and use it in `assets/js/{player, playlist, history}.js`.

## Known problems
- The colors of the seek bar are different between Chrome and Firefox. See https://github.com/jgthms/bulma/blob/1e4ae9e3e9d2f7299445de08f23448dee4e42e2d/sass/elements/progress.sass . 

## Further issues
- A feature for changing seek time from clients.

## Appearance

![jukebox-seekbar](https://user-images.githubusercontent.com/6027645/29436253-a12a67a2-83e5-11e7-82b5-54134d063c68.gif)
