### PR TITLE
Fix lock bug in speaker

### DIFF
--- a/src/model/speaker.js
+++ b/src/model/speaker.js
@@ -90,11 +90,15 @@ module.exports = class Speaker extends EventEmitter {
   async _executeWithLock(method, ...args) {
     await this.lock.acquireAsync();
 
+    let res;
     try {
-      method.apply(this, args);
+      res = method.apply(this, args);
+      if (res && res.then) res = await res;
     } finally {
       this.lock.release();
     }
+
+    return res;
   }
 
   async startWithoutLock(stream) {


### PR DESCRIPTION
This fix a lock bug for async/await in `Speaker._executeWithLock()`.